### PR TITLE
Setting binding cert with absolute path rather than relative

### DIFF
--- a/src/Solarium/PantheonCurl.php
+++ b/src/Solarium/PantheonCurl.php
@@ -15,9 +15,11 @@ class PantheonCurl extends Curl {
    */
   public function createHandle($request, $endpoint) {
     $handler = parent::createHandle($request, $endpoint);
-    curl_setopt($handler, CURLOPT_SSL_VERIFYPEER, FALSE);
-    $client_cert = '../certs/binding.pem';
-    curl_setopt($handler, CURLOPT_SSLCERT, $client_cert);
+    if (defined('PANTHEON_ENVIRONMENT')) {
+      curl_setopt($handler, CURLOPT_SSL_VERIFYPEER, FALSE);
+      $client_cert = $_SERVER['HOME'] . '/certs/binding.pem';
+      curl_setopt($handler, CURLOPT_SSLCERT, $client_cert);
+    }
     return $handler;
   }
 }


### PR DESCRIPTION
This change should accommodate alternate docroots: http://beta-static-docs.pantheonsite.io/docs/alternate-docroot/
