### PR TITLE
Switching contrib modules back to dev releases

### DIFF
--- a/tests/circle-scripts/setup-d8-repo.sh
+++ b/tests/circle-scripts/setup-d8-repo.sh
@@ -8,16 +8,12 @@ git checkout -b $TERMINUS_ENV
 # Tell Composer where to find packages.
 composer config repositories.drupal composer https://packagist.drupal-composer.org
 
-composer require drupal/search_api:8.1.x-dev#f8f9591057a387b879c7ce9af70884f6a1c51850 --prefer-dist
-composer require drupal/search_api_page:8.1.0-alpha10
+composer require drupal/search_api:8.1.x-dev --prefer-dist
+composer require drupal/search_api_page:8.1.x-dev
 
 #composer config repositories.solarium vcs git@github.com:stevector/solarium.git
 composer require solarium/solarium:3.6.*
-composer require drupal/search_api_solr:8.1.x-dev#98c0f51efb47b1dbcf85d3fd7a57ba6f57d4ba2d --prefer-dist
-
-
-
-
+composer require drupal/search_api_solr:8.1.x-dev --prefer-dist
 
 composer config repositories.search_api_pantheon vcs git@github.com:stevector/search_api_pantheon.git
 composer require  drupal/search_api_pantheon:dev-master#$CIRCLE_SHA1


### PR DESCRIPTION
search_api, search_api_solr and search_api_page had been fixed on exact commits because of bugs in dev. Those now seem to be fixed.
