### PR TITLE
Get index host and port settings via non-platform dependent func

### DIFF
--- a/src/Plugin/search_api/backend/SearchApiPantheonSolrBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiPantheonSolrBackend.php
@@ -69,8 +69,8 @@ class SearchApiPantheonSolrBackend extends SearchApiSolrBackend implements SolrB
     if (!empty($_ENV['PANTHEON_ENVIRONMENT'])) {
       $pantheon_specific_configuration = [
         'scheme' => 'https',
-        'host' => pantheon_variable_get('pantheon_index_host'),
-        'port' => pantheon_variable_get('pantheon_index_port'),
+        'host' => $_ENV['PANTHEON_INDEX_HOST'],
+        'port' => $_ENV['PANTHEON_INDEX_PORT'],
         'path' => '/sites/self/environments/' . $_ENV['PANTHEON_ENVIRONMENT'] . '/index',
       ];
     }


### PR DESCRIPTION
For a little more background on this proposed change
1. I arrived here checking out an issue over on the Kalabox queue https://github.com/kalabox/kalabox/issues/1640
2. Initially i figured we could implement `pantheon_variable_get` on our end as well to provide out of the box pantheon solr compatibility with D8 (like we do for D7) but after asking around in the #power-users group the (perhaps not accurate) suggestion was to actually do something like this PR which i think should work both on Pantheon and Kalabox (plus this helps ensure a user wont get a fatal error if they move off pantheon)

If anything in 2 above is not viable let me know and i'm more than happy to go ahead with a kalabox-side solution.
