### PR TITLE
Switch to alpha6 for search_api_solr

### DIFF
--- a/tests/circle-scripts/setup-d8-repo.sh
+++ b/tests/circle-scripts/setup-d8-repo.sh
@@ -13,7 +13,7 @@ composer require drupal/search_api_page:1.x-dev
 
 # These two lines are necessary only to force dev installs,
 # otherwise the latest releases would be used.
-composer require drupal/search_api_solr:1.x-dev --prefer-dist
+composer require drupal/search_api_solr:1.0-alpha6 --prefer-dist
 composer require drupal/search_api:1.x-dev --prefer-dist
 
 # Make sure submodules are not committed.

--- a/tests/circle-scripts/setup-d8-repo.sh
+++ b/tests/circle-scripts/setup-d8-repo.sh
@@ -14,7 +14,7 @@ composer require drupal/search_api_page:1.x-dev
 # These two lines are necessary only to force dev installs,
 # otherwise the latest releases would be used.
 composer require drupal/search_api_solr:1.0-alpha6 --prefer-dist
-composer require drupal/search_api:1.x-dev --prefer-dist
+composer require drupal/search_api:1.x-beta1 --prefer-dist
 
 # Make sure submodules are not committed.
 rm -rf modules/search_api_solr/.git/


### PR DESCRIPTION
The build is broken on the latest dev of search_api_solr (See https://www.drupal.org/node/2818001).

Setting the build script to use the last release of search_api_solr until the refactor is done in this module.
