### PR TITLE
Speed up Circle build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,7 @@ dependencies:
     - composer global require pantheon-systems/terminus "<0.13.0"
     - composer global require drush/drush:8.*
     - composer config minimum-stability dev
+    - composer remove drupal/search_api_solr
     - composer install
   post:
     - terminus auth login --machine-token=$TERMINUS_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ dependencies:
     - composer global require pantheon-systems/terminus "<0.13.0"
     - composer global require drush/drush:8.*
     - composer config minimum-stability dev
-    - composer remove drupal/search_api_solr
+    - composer remove drupal/search_api_solr --no-update
     - composer install
   post:
     - terminus auth login --machine-token=$TERMINUS_TOKEN


### PR DESCRIPTION
Right now CircleCI speeds about 5 minutes on `composer install` because composer.json includes search_api_solr, a Drupal module. That causes Drupal core to be downloaded. That step is unnecessary because core is downloaded from Pantheon (in `setup-d8-repo.sh`) for the real test.
