### PR TITLE
Remove patches and README from git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,4 @@
 /tests export-ignore
-/patches export-ignore
 /circle.yml export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/README.md export-ignore


### PR DESCRIPTION
The patches dir doesn't exist anymore. And people probably want the README file when using the module.
