### PR TITLE
Switch to Terminus 1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ machine:
   environment:
     TERMINUS_ENV: ci-$CIRCLE_BUILD_NUM
     TERMINUS_SITE: search-api-solr-d8
+    PATH: $PATH:~/terminus/bin
 
 dependencies:
   cache_directories:
@@ -24,13 +25,14 @@ dependencies:
       } &> /dev/null
   override:
     - composer global require "hirak/prestissimo:^0.3"
-    - composer global require pantheon-systems/terminus "<0.13.0"
+    - git clone https://github.com/pantheon-systems/terminus.git ~/terminus
+    - cd ~/terminus && composer install
     - composer global require drush/drush:8.*
     - composer config minimum-stability dev
     - composer remove drupal/search_api_solr --no-update
     - composer install
   post:
-    - terminus auth login --machine-token=$TERMINUS_TOKEN
+    - terminus auth:login --machine-token=$TERMINUS_TOKEN
 test:
   pre:
     - ./vendor/bin/phpcs --report=full --extensions=php,module,inc,theme,info,install --standard=vendor/drupal/coder/coder_sniffer/Drupal . --ignore=vendor,modules,core,drush,patches,tests

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ dependencies:
       } &> /dev/null
   override:
     - composer global require "hirak/prestissimo:^0.3"
-    - git clone --branch ensure-dir https://github.com/stevector/terminus.git ~/terminus
+    - git clone --branch ensure-dir--and-site-env-lookup https://github.com/stevector/terminus.git ~/terminus
     - cd ~/terminus && composer install
     - composer global require drush/drush:8.*
     - composer config minimum-stability dev

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ machine:
   environment:
     TERMINUS_ENV: ci-$CIRCLE_BUILD_NUM
     TERMINUS_SITE: search-api-solr-d8
+    SITE_ENV: $TERMINUS_SITE.$TERMINUS_ENV
     PATH: $PATH:~/terminus/bin
 
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ dependencies:
       } &> /dev/null
   override:
     - composer global require "hirak/prestissimo:^0.3"
-    - git clone --branch ensure-dir--and-site-env-lookup https://github.com/stevector/terminus.git ~/terminus
+    - git clone --branch master https://github.com/pantheon-systems/terminus.git ~/terminus
     - cd ~/terminus && composer install
     - composer global require drush/drush:8.*
     - composer config minimum-stability dev

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ dependencies:
       } &> /dev/null
   override:
     - composer global require "hirak/prestissimo:^0.3"
-    - git clone https://github.com/pantheon-systems/terminus.git ~/terminus
+    - git clone --branch ensure-dir https://github.com/stevector/terminus.git ~/terminus
     - cd ~/terminus && composer install
     - composer global require drush/drush:8.*
     - composer config minimum-stability dev

--- a/tests/circle-scripts/create-fresh-d8-site.sh
+++ b/tests/circle-scripts/create-fresh-d8-site.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 # @todo, pull in upstream updates, wipe and install drupal.
 # Also, it might be cleaner to create an entirely new D8 site rather than making
 # multidevs off of the same one repeatedly.

--- a/tests/circle-scripts/create-fresh-d8-site.sh
+++ b/tests/circle-scripts/create-fresh-d8-site.sh
@@ -3,8 +3,7 @@
 # @todo, pull in upstream updates, wipe and install drupal.
 # Also, it might be cleaner to create an entirely new D8 site rather than making
 # multidevs off of the same one repeatedly.
-terminus site create-env --to-env=$TERMINUS_ENV --from-env=dev
-yes | terminus site clone-content --to-env=$TERMINUS_ENV --from-env=dev --db-only
+terminus env:create  $TERMINUS_SITE.dev $TERMINUS_ENV
 
 # @todo, this command gives an error
 # [error] You must upgrade to a business or an elite plan to use Solr.

--- a/tests/circle-scripts/create-fresh-d8-site.sh
+++ b/tests/circle-scripts/create-fresh-d8-site.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -x
 
 # @todo, pull in upstream updates, wipe and install drupal.
 # Also, it might be cleaner to create an entirely new D8 site rather than making

--- a/tests/circle-scripts/enable-modules.sh
+++ b/tests/circle-scripts/enable-modules.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 terminus drush $SITE_ENV "cache-rebuild"
 terminus drush $SITE_ENV "pml"
 # Uninstall core search to reduce confusion in the UI.

--- a/tests/circle-scripts/enable-modules.sh
+++ b/tests/circle-scripts/enable-modules.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 terminus drush "cache-rebuild"
 terminus drush "pml"
 # Uninstall core search to reduce confusion in the UI.

--- a/tests/circle-scripts/enable-modules.sh
+++ b/tests/circle-scripts/enable-modules.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-terminus drush $TERMINUS_SITE.$TERMINUS_ENV "cache-rebuild"
-terminus drush $TERMINUS_SITE.$TERMINUS_ENV "pml"
+terminus drush $SITE_ENV "cache-rebuild"
+terminus drush $SITE_ENV "pml"
 # Uninstall core search to reduce confusion in the UI.
-terminus drush $TERMINUS_SITE.$TERMINUS_ENV "pm-uninstall search -y"
-terminus drush $TERMINUS_SITE.$TERMINUS_ENV "en -y search_api_pantheon search_api_solr search_api_page search_api"
+terminus drush $SITE_ENV "pm-uninstall search -y"
+terminus drush $SITE_ENV "en -y search_api_pantheon search_api_solr search_api_page search_api"
 # @todo, would this test benefit from exporting/committing config?
-terminus connection:set $TERMINUS_SITE.$TERMINUS_ENV sftp
+terminus connection:set $SITE_ENV sftp

--- a/tests/circle-scripts/enable-modules.sh
+++ b/tests/circle-scripts/enable-modules.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-terminus drush $TERMINUS_SITE.$TERMINUS_ENV "cache-rebuild"
-terminus drush $TERMINUS_SITE.$TERMINUS_ENV "pml"
+terminus drush "cache-rebuild"
+terminus drush "pml"
 # Uninstall core search to reduce confusion in the UI.
-terminus drush $TERMINUS_SITE.$TERMINUS_ENV "pm-uninstall search -y"
-terminus drush $TERMINUS_SITE.$TERMINUS_ENV "en -y search_api_pantheon search_api_solr search_api_page search_api"
+terminus drush "pm-uninstall search -y"
+terminus drush "en -y search_api_pantheon search_api_solr search_api_page search_api"
 # @todo, would this test benefit from exporting/committing config?
-terminus connection:set $TERMINUS_SITE.$TERMINUS_ENV sftp
+terminus connection:set sftp

--- a/tests/circle-scripts/enable-modules.sh
+++ b/tests/circle-scripts/enable-modules.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 terminus drush $TERMINUS_SITE.$TERMINUS_ENV "cache-rebuild"
 terminus drush $TERMINUS_SITE.$TERMINUS_ENV "pml"
 # Uninstall core search to reduce confusion in the UI.

--- a/tests/circle-scripts/enable-modules.sh
+++ b/tests/circle-scripts/enable-modules.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-terminus drush "cache-rebuild"
-terminus drush "pml"
+terminus drush $TERMINUS_SITE.$TERMINUS_ENV "cache-rebuild"
+terminus drush $TERMINUS_SITE.$TERMINUS_ENV "pml"
 # Uninstall core search to reduce confusion in the UI.
-terminus drush "pm-uninstall search -y"
-terminus drush "en -y search_api_pantheon search_api_solr search_api_page search_api"
+terminus drush $TERMINUS_SITE.$TERMINUS_ENV "pm-uninstall search -y"
+terminus drush $TERMINUS_SITE.$TERMINUS_ENV "en -y search_api_pantheon search_api_solr search_api_page search_api"
 # @todo, would this test benefit from exporting/committing config?
-terminus connection:set sftp
+terminus connection:set $TERMINUS_SITE.$TERMINUS_ENV sftp

--- a/tests/circle-scripts/enable-modules.sh
+++ b/tests/circle-scripts/enable-modules.sh
@@ -2,10 +2,10 @@
 
 set -x
 
-terminus drush $SITE_ENV "cache-rebuild"
-terminus drush $SITE_ENV "pml"
+terminus drush $SITE_ENV -- cache-rebuild
+terminus drush $SITE_ENV -- pml
 # Uninstall core search to reduce confusion in the UI.
-terminus drush $SITE_ENV "pm-uninstall search -y"
-terminus drush $SITE_ENV "en -y search_api_pantheon search_api_solr search_api_page search_api"
+terminus drush $SITE_ENV -- pm-uninstall search -y
+terminus drush $SITE_ENV -- en -y search_api_pantheon search_api_solr search_api_page search_api
 # @todo, would this test benefit from exporting/committing config?
 terminus connection:set $SITE_ENV sftp

--- a/tests/circle-scripts/enable-modules.sh
+++ b/tests/circle-scripts/enable-modules.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 terminus drush "cache-rebuild"
 terminus drush "pml"
 # Uninstall core search to reduce confusion in the UI.

--- a/tests/circle-scripts/enable-modules.sh
+++ b/tests/circle-scripts/enable-modules.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -ex
-
 terminus drush $TERMINUS_SITE.$TERMINUS_ENV "cache-rebuild"
 terminus drush $TERMINUS_SITE.$TERMINUS_ENV "pml"
 # Uninstall core search to reduce confusion in the UI.

--- a/tests/circle-scripts/enable-modules.sh
+++ b/tests/circle-scripts/enable-modules.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-terminus drush "cache-rebuild"
-terminus drush "pml"
+terminus drush $TERMINUS_SITE.$TERMINUS_ENV "cache-rebuild"
+terminus drush $TERMINUS_SITE.$TERMINUS_ENV "pml"
 # Uninstall core search to reduce confusion in the UI.
-terminus drush "pm-uninstall search -y"
-terminus drush "en -y search_api_pantheon search_api_solr search_api_page search_api"
+terminus drush $TERMINUS_SITE.$TERMINUS_ENV "pm-uninstall search -y"
+terminus drush $TERMINUS_SITE.$TERMINUS_ENV "en -y search_api_pantheon search_api_solr search_api_page search_api"
 # @todo, would this test benefit from exporting/committing config?
-terminus site set-connection-mode --mode=sftp
+terminus connection:set $TERMINUS_SITE.$TERMINUS_ENV sftp

--- a/tests/circle-scripts/setup-d8-repo.sh
+++ b/tests/circle-scripts/setup-d8-repo.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 # Bring the code down to Circle so that modules can be added via composer.
 git clone $(terminus connection:info $TERMINUS_SITE.$TERMINUS_ENV --field=git_url) drupal8
 cd drupal8

--- a/tests/circle-scripts/setup-d8-repo.sh
+++ b/tests/circle-scripts/setup-d8-repo.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -ex
-
 # Bring the code down to Circle so that modules can be added via composer.
 git clone $(terminus connection:info $TERMINUS_SITE.$TERMINUS_ENV --field=git_url) drupal8
 cd drupal8

--- a/tests/circle-scripts/setup-d8-repo.sh
+++ b/tests/circle-scripts/setup-d8-repo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Bring the code down to Circle so that modules can be added via composer.
-git clone $(terminus site connection-info --field=git_url) drupal8
+git clone $(terminus connection:info $TERMINUS_SITE.$TERMINUS_ENV --field=git_url) drupal8
 cd drupal8
 git checkout -b $TERMINUS_ENV
 

--- a/tests/circle-scripts/setup-d8-repo.sh
+++ b/tests/circle-scripts/setup-d8-repo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Bring the code down to Circle so that modules can be added via composer.
-git clone $(terminus connection:info $TERMINUS_SITE.$TERMINUS_ENV --field=git_url) drupal8
+git clone $(terminus connection:info $SITE_ENV --field=git_url) drupal8
 cd drupal8
 git checkout -b $TERMINUS_ENV
 

--- a/tests/circle-scripts/verify-solr.sh
+++ b/tests/circle-scripts/verify-solr.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 # Create a drush alias file so that Behat tests can be executed against Pantheon.
 terminus sites aliases
 # Drush Behat driver fails without this option.

--- a/tests/circle-scripts/verify-solr.sh
+++ b/tests/circle-scripts/verify-solr.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -ex
-
 # Create a drush alias file so that Behat tests can be executed against Pantheon.
 terminus aliases
 # Drush Behat driver fails without this option.

--- a/tests/circle-scripts/verify-solr.sh
+++ b/tests/circle-scripts/verify-solr.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# @todo, This step should not be necessary.
+# It should be taken care of in terminus aliases
+mkdir ~/.drush
+
 # Create a drush alias file so that Behat tests can be executed against Pantheon.
 terminus aliases
 # Drush Behat driver fails without this option.

--- a/tests/circle-scripts/verify-solr.sh
+++ b/tests/circle-scripts/verify-solr.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Create a drush alias file so that Behat tests can be executed against Pantheon.
-terminus sites aliases
+terminus aliases
 # Drush Behat driver fails without this option.
 echo "\$options['strict'] = 0;" >> ~/.drush/pantheon.aliases.drushrc.php
 

--- a/tests/circle-scripts/verify-solr.sh
+++ b/tests/circle-scripts/verify-solr.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# @todo, This step should not be necessary.
-# It should be taken care of in terminus aliases
-mkdir ~/.drush
-
 # Create a drush alias file so that Behat tests can be executed against Pantheon.
 terminus aliases
 # Drush Behat driver fails without this option.


### PR DESCRIPTION
This is a PR to verify that CircleCI scripts for modules/plugins can use Terminus 1 instead of Terminus 0.

Right now this PR uses a fork of Terminus 1 because of a bug in `terminus aliases`: https://github.com/pantheon-systems/terminus/pull/1455