### PR TITLE
WIP - Support for MoreLikeThis

### DIFF
--- a/src/Plugin/SolrConnector/PantheonSolrConnector.php
+++ b/src/Plugin/SolrConnector/PantheonSolrConnector.php
@@ -150,6 +150,7 @@ class PantheonSolrConnector extends StandardSolrConnector {
   protected function connect() {
     if (!$this->solr) {
       $this->solr = new Client();
+      $this->solr->registerQueryType('mlt', "Drupal\search_api_pantheon\Solarium\MoreLikeThisQuery");
 
       // The parent method is overridden so that this alternate adapter class
       // can be set. This line is the only difference from the parent method.

--- a/src/Solarium/MoreLikeThisQuery.php
+++ b/src/Solarium/MoreLikeThisQuery.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Override MoreLikeThis for Solr 3 compatiblity.
+ */
+
+namespace Drupal\search_api_pantheon\Solarium;
+use Solarium\Core\Client\Adapter\Curl;
+use Solarium\QueryType\MoreLikeThis\Query;
+
+class MoreLikeThisQuery extends Query {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($options = NULL) {
+    parent::__construct($options);
+    // Force the handler to select because Panthon uses Solr 3
+    // which did have a separate handler for mlt (I think?)
+    $this->options['handler'] = 'select';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setQuery($query, $bind = NULL) {
+    $this->addParam("qt", "mlt");
+    return parent::setQuery($query, $bind);
+  }
+}


### PR DESCRIPTION
I heard an internal report of "More Like This" not working in D8. So I set up fresh D7 and D8 sites and configured basic Views. I noticed that the D7 View was hitting a url in the solr server that contained `select` in the path and had `qt=mlt` as a GET param. D8's url contained `mlt` and did not use the the QueryType (`qt`) GET param.

As far as I can tell this difference is a result of [the way Solarium constructs MLT queries](https://github.com/solariumphp/solarium/blob/06b243b6ca8fb19c427ff942bbc3586c47470d02/library/Solarium/QueryType/MoreLikeThis/Query.php#L64). Solarium is used in D8 but not D7.

I am assuming that this works fine on Solr 4 and above but not on Solr 3. Override this class from Solarium was easy enough so that's what I'm trying in this PR.

Then again, it's possible that a change in `solrconfig.xml` would make this change unnecessary.