### PR TITLE
Set search_api_solr to 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
         }
     },
     "require": {
-        "drupal/search_api_solr": "~1.0-beta1"
+        "drupal/search_api_solr": "1.6"
     }
 }


### PR DESCRIPTION
**Description of issue:**
Updates made to Search API Solr 8.x-1.7 [break Solr on Pantheon](https://www.drupal.org/project/search_api_solr/issues/3195404). This issue still exists in 8.x-1.10.

**Steps to repro:** Follow [the docs](https://pantheon.io/docs/solr-drupal-8#install-solr-on-drupal-8) for installing Apache Solr on a Pantheon Drupal site.

**Expected results:** Solr is successfully installed and configured.
**Actual results:** Status report errors:
- SEARCH APIThe search server "Pantheon" is currently not available
- SOLR SERVERS1 server. The Solr server of Pantheon could not be reached.

**Solution:**
 I was able to get Solr working again in my project by adding `"drupal/search_api_solr": "1.6"` to composer.json. This PR sets the version to 1.6 instead of anything above 1.0-beta1. 