### PR TITLE
Add missing schema

### DIFF
--- a/config/schema/search_api_pantheon.connector.pantheon.schema.yml
+++ b/config/schema/search_api_pantheon.connector.pantheon.schema.yml
@@ -1,0 +1,51 @@
+plugin.plugin_configuration.search_api_solr_connector.pantheon:
+  type: config_object
+  label: 'Search API Solr Pantheon connector settings'
+  mapping:
+    timeout:
+      type: integer
+      label: 'Timeout for search queries'
+    index_timeout:
+      type: integer
+      label: 'Timeout for indexing requests'
+    optimize_timeout:
+      type: integer
+      label: 'Timeout for optimize requests'
+    finalize_timeout:
+      type: integer
+      label: 'Timeout for finalize requests'
+    commit_within:
+      type: integer
+      label: 'Time until a soft commit has to happen'
+    workarounds:
+      type: mapping
+      mapping:
+        solr_version:
+          type: string
+          label: 'Solr version override'
+        http_method:
+          type: string
+          label: 'The HTTP method to use for sending queries'
+        skip_schema_check:
+          type: integer
+          label: 'Do not validate if the schema is correct'
+    advanced:
+      type: mapping
+      mapping:
+        jmx:
+          type: integer
+          label: 'Enable JMX'
+        solr_install_dir:
+          type: string
+          label: 'solr.install.dir property'
+    jmx:
+      type: boolean
+      label: 'Enable JMX'
+    skip_schema_check:
+      type: boolean
+      label: 'Do not validate if the schema is correct'
+    endpoint:
+      type: sequence
+      label: 'Endpoints'
+      sequence:
+        type: string


### PR DESCRIPTION
Our test suite complains about a missing schema for `search_api.server.pantheon_solr8:backend_config.connector_config`. This takes care of it. 

The schema here mostly mirrors `search_api_solr.connector.standard.schema.yml`, with a couple of tweaks to match what's actually in `search_api.server.pantheon_solr8.yml`