### PR TITLE
Fallback for $_SERVER['HOME']

### DIFF
--- a/src/Services/PantheonGuzzle.php
+++ b/src/Services/PantheonGuzzle.php
@@ -61,7 +61,7 @@ class PantheonGuzzle extends Client implements
      * ), 'logger'
      * );
      **/
-    $cert = $_SERVER['HOME'] . '/certs/binding.pem';
+    $cert = ($_SERVER['HOME'] ?? '') . '/certs/binding.pem';
     $config = [
           'base_uri' => $endpoint->getBaseUri(),
           'http_errors' => FALSE,


### PR DESCRIPTION
For some reason in my test runner, `$_SERVER['HOME']` is not set, and the undefined index notice causes the test to fail. 