### PR TITLE
Adjusted syntax and language for install requirements error message

### DIFF
--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -4,14 +4,6 @@
  * @file
  */
 
-const SEARCH_API_PANTHEON_ERROR_MESSAGE = <<<EOF
-
-      Search API Pantheon needs to be enabled with, first, enabling search on the site,
-      and then an entry in the pantheon.yml to switch the environment to solr v8. Please refer to
-      <a href="https://pantheon.io/docs/guides/solr-drupal/solr-drupal-9">this tutorial:</a>
-
-EOF;
-
 /**
  * Implements hook_requirements().
  */
@@ -28,7 +20,13 @@ function search_api_pantheon_requirements($phase) {
 
   if ($severity == REQUIREMENT_ERROR) {
     \Drupal::messenger()
-      ->addError(SEARCH_API_PANTHEON_ERROR_MESSAGE);
+      ->addError(
+        t(
+          'Search API Pantheon needs to be enabled, first by enabling the module on the site,
+          then by adding an entry in your <code>pantheon.yml</code> file to switch the environment to Solr v8.
+          Please refer to <a href="https://pantheon.io/docs/guides/solr-drupal/solr-drupal-9">this tutorial</a>.'
+        )
+      );
   }
 
   $requirements['search_api_pantheon'] = [


### PR DESCRIPTION
I noticed while getting the module installed and configured that the <code>.install</code> file's error message (which I saw because I hadn't updated my <code>pantheon.yml</code> file yet) had some HTML syntax issues. I adjusted it so that the link worked, and tweaked the language a bit to hopefully be a bit clearer.

Before:
![Screen Shot 2021-10-13 at 6 09 03 PM](https://user-images.githubusercontent.com/848721/137221926-bbc8f94f-d435-47d1-aa19-0c3acb38f218.png)

After:
![Screen Shot 2021-10-13 at 6 08 16 PM](https://user-images.githubusercontent.com/848721/137221956-dbf91667-587b-4d6c-8eb9-c9a58a32aebd.png)