### PR TITLE
Use different code for D8 and D9.

### DIFF
--- a/src/Services/SolariumClient.php
+++ b/src/Services/SolariumClient.php
@@ -25,6 +25,7 @@ class SolariumClient extends Client {
     $drupal_major_parts = explode('.', \Drupal::VERSION);
     $drupal_major = reset($drupal_major_parts);
     if ($drupal_major < 9) {
+      // Use the bridge only if Drupal 8.
       $event_dispatcher = new Psr14Bridge($event_dispatcher);
     }
     parent::__construct(

--- a/src/Services/SolariumClient.php
+++ b/src/Services/SolariumClient.php
@@ -22,9 +22,14 @@ class SolariumClient extends Client {
    * Class constructor.
    */
   public function __construct(PantheonGuzzle $guzzle, Endpoint $endpoint, LoggerChannelFactoryInterface $logger_factory, ContainerAwareEventDispatcher $event_dispatcher) {
+    $drupal_major_parts = explode('.', \Drupal::VERSION);
+    $drupal_major = reset($drupal_major_parts);
+    if ($drupal_major < 9) {
+      $event_dispatcher = new Psr14Bridge($event_dispatcher);
+    }
     parent::__construct(
           $guzzle->getPsr18Adapter(),
-          new Psr14Bridge($event_dispatcher),
+          $event_dispatcher,
           ['endpoint' => [$endpoint]]
       );
     $this->logger = $logger_factory->get('PantheonSolariumClient');


### PR DESCRIPTION
This restores compatibility with search_api_solr_devel by not doing any changes in the way D9 work.