### PR TITLE
CMS-394: Add Drupal 8 tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,6 @@ jobs:
           ./vendor/bin/robo test:full $DRUPAL_VERSION $TERMINUS_SITE
 
       - name: Cleanup sites
-        if: always
+        if: ${{ always() }}
         run: |
           ./vendor/bin/robo test:delete-sites

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,8 @@ jobs:
         run: |
           export TERMINUS_ORG=$TERMINUS_ORG
           ./vendor/bin/robo test:full $DRUPAL_VERSION $TERMINUS_SITE
+
+      - name: Cleanup sites
+        if: always
+        run: |
+          ./vendor/bin/robo test:delete-sites

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SANDBOX_SSH_KEY }}
 
+      - name: Composer install
+        run: composer install --ignore-platform-req=php
+
       - name: Run tests
         run: |
           export TERMINUS_ORG=$TERMINUS_ORG

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,12 @@ on:
   schedule:
     - cron: '0 0 * * *'
 jobs:
-  # Checkout in separate job because docker image is alpine based and checkout action doesn't work.
-  build_test:
+  linting:
     runs-on: ubuntu-latest
     container:
       image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
       options: --user root
-    name: Build and test
+    name: Code linting
     env:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
       TERM: dumb
@@ -29,17 +28,43 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Login
-        run: |
-          git config --global user.email "$GIT_EMAIL"
-          git config --global user.name "Github Actions"
-          mkdir -p /root/.ssh && echo "${{ secrets.SSH_CONFIG }}" >> "/root/.ssh/config"
-
       - name: Composer install
         run: composer install --ignore-platform-req=php
 
       - name: Code sniff
         run: composer run-script code:lint
+  build_test:
+    strategy:
+      matrix:
+        drupal-version: [ 9, 8 ]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
+      options: --user root
+    name: Build and test (Drupal ${{ matrix.drupal-version }})
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+      TERM: dumb
+      TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
+      TERMINUS_SITE: ${{ secrets.TERMINUS_SITE }}
+      TERMINUS_ORG: ${{ secrets.TERMINUS_ORG }}
+      GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
+      GITHUB_RUN_NUMBER: ${{ github.run_number }}
+      COMMIT_SHA: ${{ github.sha }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      SANDBOX_SSH_KEY: ${{ secrets.SANDBOX_SSH_KEY }}
+      BASH_ENV: ~/.bashrc
+      DRUPAL_VERSION: ${{ matrix.drupal-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login
+        run: |
+          git config --global user.email "$GIT_EMAIL"
+          git config --global user.name "Github Actions"
+          mkdir -p /root/.ssh && echo "${{ secrets.SSH_CONFIG }}" >> "/root/.ssh/config"
 
       - name: Log in to Terminus
         run: |
@@ -57,14 +82,5 @@ jobs:
 
       - name: Run tests
         run: |
-          export TERMINUS_ENV=$GITHUB_RUN_NUMBER
-          export SITE_ENV=$TERMINUS_SITE.$TERMINUS_ENV
           export TERMINUS_ORG=$TERMINUS_ORG
-          if [ -n "$( echo $GITHUB_REF | sed -n '/heads/p')" ] ; then
-            BRANCH=`echo $GITHUB_REF | cut -c12-`
-            export GIT_REF="dev-${BRANCH}#${COMMIT_SHA}"
-          else
-            TAG=`echo $GITHUB_REF | cut -c11-`
-            export GIT_REF=${TAG}
-          fi
-          ./vendor/bin/robo test:full $TERMINUS_SITE
+          ./vendor/bin/robo test:full $DRUPAL_VERSION $TERMINUS_SITE

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -576,6 +576,7 @@ class RoboFile extends Tasks {
           'cim',
           '--partial',
           '--source=modules/composer/search_api_pantheon/.ci/config',
+          '-y'
         )
         ->run();
       if (!$result->wasSuccessful()) {

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -321,13 +321,13 @@ class RoboFile extends Tasks {
    * @param string $constraint
    *   The constraint to use for the search_api_pantheon module.
    */
-  public function testRequireSolr(string $site_name, string $contraint = '^8') {
+  public function testRequireSolr(string $site_name, string $constraint = '^8') {
     $site_folder = $this->getSiteFolder($site_name);
     chdir($site_folder);
     $this->taskExec('composer')
       ->args(
               'require',
-              'pantheon-systems/search_api_pantheon ' . $contraint,
+              'pantheon-systems/search_api_pantheon ' . $constraint,
               'drupal/search_api_autocomplete',
               'drupal/search_api_sorts',
               'drupal/facets',
@@ -360,7 +360,7 @@ class RoboFile extends Tasks {
    * @param string $commit_msg
    *   The commit message to use.
    */
-  public function testGitPush(string $site_name, $commit_msg = 'Changes committed from demo script.') {
+  public function testGitPush(string $site_name, string $commit_msg = 'Changes committed from demo script.') {
     $site_folder = $this->getSiteFolder($site_name);
     chdir($site_folder);
     try {

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -46,7 +46,7 @@ class RoboFile extends Tasks {
       $site_name = substr(\uniqid('test-'), 0, 12);
       if ($_SERVER['GITHUB_RUN_NUMBER']) {
         // Ensure that 2 almost parallel runs do not collide.
-        $site_name .= '-' . $_SERVER['GITHUB_RUN_NUMBER'];
+        $site_name .= '-' . $drupal_version . '-'. $_SERVER['GITHUB_RUN_NUMBER'];
       }
     }
     $this->testCreateSite($site_name, $options);

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -47,6 +47,7 @@ class RoboFile extends Tasks {
     $filenames = explode("\n", $file_contents);
     foreach ($filenames as $site_name) {
       if ($site_name) {
+        $this->output()->writeln("Deleting site $site_name.");
         $this->taskExec(static::$TERMINUS_EXE)
           ->args('site:delete', '-y', $site_name)
           ->run();

--- a/search_api_pantheon.info.yml
+++ b/search_api_pantheon.info.yml
@@ -1,7 +1,6 @@
 name: Search API Pantheon
 type: module
 description: Search API + Solr + Pantheon integration
-version: 8.0.x
 core_version_requirement: ^8.8 || ^9
 package: Search
 dependencies:


### PR DESCRIPTION
This PR:
- Separates linting to its own job.
- Creates a jobs matrix for D8 and D9 to run in parallel.
- Adds a new D8 job that downgrades to D8 before doing the usual tests.
- Adds lots of functions and inline comments to the Robo file.