### PR TITLE
Remove dependencies that are already added by core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,8 @@
     "require": {
         "php": ">=7.4",
         "ext-curl": "*",
-        "ext-json": "*",
         "ext-zip": "*",
         "drupal/search_api_solr": "^4.2.1",
-        "guzzlehttp/guzzle": "^6",
         "http-interop/http-factory-guzzle": "^1.0",
         "php-http/guzzle6-adapter": "^2.0",
         "psr/event-dispatcher": "^1.0"


### PR DESCRIPTION
There's no reason to include dependencies in composer.json for things that core already adds.