### PR TITLE
Force cleanup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,3 +230,7 @@ with the concept usage in a Solr context:
 
 * `drush search-api-pantheon:select` (`saps`) This command will run the given query against Solr server. It's recommended to use
   `?debug=true` in any Solr page to get a good query to pass to this command to debug results.
+
+
+* `drush search-api-pantheon:force-cleanup` (`sapfc`) This command will delete all of the contents for the given
+  Solr server (no matter if hash or index_id have changed).

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -126,7 +126,6 @@ class Query extends DrushCommands {
    * @aliases sapfc
    *
    * @throws \Drupal\search_api_solr\SearchApiSolrException
-   * @throws \JsonException
    * @throws \Exception
    */
   public function forceServerClean($server_id = 'pantheon_solr8') {

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -136,17 +136,18 @@ class Query extends DrushCommands {
 
     $backend = $server->getBackend();
     $connector = $backend->getSolrConnector();
+    $query_helper = \Drupal::service('solarium.query_helper');
 
     $properties['status'] = TRUE;
     $properties['read_only'] = FALSE;
     foreach ($server->getIndexes($properties) as $index) {
       // Since the index ID we use for indexing can contain arbitrary
       // prefixes, we have to escape it for use in the query.
-      $index_id = $backend->queryHelper->escapeTerm($this->getTargetedIndexId($index));
-      $site_hash = $backend->queryHelper->escapeTerm($this->getTargetedSiteHash($index));
+      $index_id = $query_helper->escapeTerm($this->getTargetedIndexId($index));
+      //$site_hash = $query_helper->escapeTerm($this->getTargetedSiteHash($index));
 
       $query = '+index_id:' . $index_id;
-      $query .= ' +hash:' . $site_hash;
+      //$query .= ' +hash:' . $site_hash;
 
       var_dump($query);
 

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -131,26 +131,16 @@ class Query extends DrushCommands {
    */
   public function forceServerClean($server_id = 'pantheon_solr8') {
 
-    // @todo Improve.
     $server = Server::load($server_id);
-
     $backend = $server->getBackend();
     $connector = $backend->getSolrConnector();
-    $query_helper = \Drupal::service('solarium.query_helper');
 
     $properties['status'] = TRUE;
     $properties['read_only'] = FALSE;
     foreach ($server->getIndexes($properties) as $index) {
-      // Since the index ID we use for indexing can contain arbitrary
-      // prefixes, we have to escape it for use in the query.
-      $index_id = $query_helper->escapeTerm($backend->getTargetedIndexId($index));
-      //$site_hash = $query_helper->escapeTerm($backend->getTargetedSiteHash($index));
-
+      // We are sure this server is only available to this env so it is safe
+      // to delete all of the server contents.
       $query = '*:*';
-      //$query = '+index_id:' . $index_id;
-      //$query .= ' +hash:' . $site_hash;
-
-      var_dump($query);
 
       $update_query = $connector->getUpdateQuery();
       $update_query->addDeleteQuery($query);

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -122,7 +122,6 @@ class Query extends DrushCommands {
    *
    * @command search-api-pantheon:force-cleanup
    *
-   *
    * @aliases sapfc
    *
    * @throws \Drupal\search_api_solr\SearchApiSolrException

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -143,7 +143,12 @@ class Query extends DrushCommands {
       // Since the index ID we use for indexing can contain arbitrary
       // prefixes, we have to escape it for use in the query.
       $index_id = $backend->queryHelper->escapeTerm($this->getTargetedIndexId($index));
+      $site_hash = $backend->queryHelper->escapeTerm($this->getTargetedSiteHash($index));
+
       $query = '+index_id:' . $index_id;
+      $query .= ' +hash:' . $site_hash;
+
+      var_dump($query);
 
       $update_query = $connector->getUpdateQuery();
       $update_query->addDeleteQuery($query);

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -146,7 +146,8 @@ class Query extends DrushCommands {
       $index_id = $query_helper->escapeTerm($backend->getTargetedIndexId($index));
       //$site_hash = $query_helper->escapeTerm($backend->getTargetedSiteHash($index));
 
-      $query = '+index_id:' . $index_id;
+      $query = '';
+      //$query = '+index_id:' . $index_id;
       //$query .= ' +hash:' . $site_hash;
 
       var_dump($query);

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -143,8 +143,8 @@ class Query extends DrushCommands {
     foreach ($server->getIndexes($properties) as $index) {
       // Since the index ID we use for indexing can contain arbitrary
       // prefixes, we have to escape it for use in the query.
-      $index_id = $query_helper->escapeTerm($this->getTargetedIndexId($index));
-      //$site_hash = $query_helper->escapeTerm($this->getTargetedSiteHash($index));
+      $index_id = $query_helper->escapeTerm($backend->getTargetedIndexId($index));
+      //$site_hash = $query_helper->escapeTerm($backend->getTargetedSiteHash($index));
 
       $query = '+index_id:' . $index_id;
       //$query .= ' +hash:' . $site_hash;
@@ -153,7 +153,7 @@ class Query extends DrushCommands {
 
       $update_query = $connector->getUpdateQuery();
       $update_query->addDeleteQuery($query);
-      $connector->update($update_query, $this->getCollectionEndpoint($index));
+      $connector->update($update_query, $backend->getCollectionEndpoint($index));
       \Drupal::state()->set('search_api_solr.' . $index->id() . '.last_update', \Drupal::time()->getCurrentTime());
     }
 

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -146,7 +146,7 @@ class Query extends DrushCommands {
       $index_id = $query_helper->escapeTerm($backend->getTargetedIndexId($index));
       //$site_hash = $query_helper->escapeTerm($backend->getTargetedSiteHash($index));
 
-      $query = '';
+      $query = '*:*';
       //$query = '+index_id:' . $index_id;
       //$query .= ' +hash:' . $site_hash;
 

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -139,7 +139,7 @@ class Query extends DrushCommands {
 
     $properties['status'] = TRUE;
     $properties['read_only'] = FALSE;
-    foreach ($this->getIndexes($properties) as $index) {
+    foreach ($server->getIndexes($properties) as $index) {
       // Since the index ID we use for indexing can contain arbitrary
       // prefixes, we have to escape it for use in the query.
       $index_id = $backend->queryHelper->escapeTerm($this->getTargetedIndexId($index));


### PR DESCRIPTION
Adds new search-api-pantheon:force-cleanup that will delete everything in the given server no matter index_id or hash.

This is useful for situations like following:
1) User created an index, messed things up and deleted the index before deleting the content (that content will be stuck there forever)
2) search_api_solr.site_hash state changed (maybe because db was copied from one env to another, or for some other unknown reason)

Under these situations, going to the server and clicking the "Delete all server contents" button really doesn't work because that's filtered by hash and index_id. This new command does the same but removing those filters so it will effectively clean the server contents.