### PR TITLE
Drupal 10 compatibility fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,10 +42,9 @@
         "ext-json": "*",
         "ext-zip": "*",
         "drupal/search_api_solr": "^4.2",
-        "guzzlehttp/guzzle": "^6.5.2",
+        "guzzlehttp/guzzle": "^6.5.2|^7.4",
         "http-interop/http-factory-guzzle": "^1.0",
         "kint-php/kint": "^4.1",
-        "php-http/guzzle6-adapter": "^2.0",
         "psr/event-dispatcher": "^1.0",
         "symfony/finder": "^4|^5"
     },

--- a/search_api_pantheon.info.yml
+++ b/search_api_pantheon.info.yml
@@ -1,7 +1,7 @@
 name: Search API Pantheon
 type: module
 description: Search API + Solr + Pantheon integration
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^8.8 || ^9 || ^10
 package: Search
 dependencies:
   - search_api_solr:search_api_solr

--- a/tests/Unit/GuzzleClassTest.php
+++ b/tests/Unit/GuzzleClassTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Exception\RequestException;
+use Psr\Log\LoggerInterface;
 
 /**
  * Guzzle Class Test.


### PR DESCRIPTION
See comment here:
https://www.drupal.org/project/search_api_pantheon/issues/3289519#comment-14789310

I determined that the Guzzle6 adapter was not being used anymore, so I have bumped the Guzzle requirement to allow Drupal 10's Guzzle 7.5.0. I believe this should get us to full Drupal 10 compatibility. 

The Project Update Bot also changed a few lines in the unit tests, but I suspect that would cause those tests to fail against older Drupal, so I have reverted those changes.