### PR TITLE
Issue #3261858 by DamienMcKenna, heddn: The path of a URI with an aut…

### DIFF
--- a/src/Services/PantheonGuzzle.php
+++ b/src/Services/PantheonGuzzle.php
@@ -166,7 +166,7 @@ class PantheonGuzzle extends Client implements
     $path_parts = array_filter($path_parts, function ($item) {
         return !empty($item);
     });
-    $uri = $uri->withPath(implode('/', $path_parts));
+    $uri = $uri->withPath('/' . ltrim(implode('/', $path_parts), '/'));
     return $request->withUri($uri);
   }
 


### PR DESCRIPTION
…hority must start with a slash "/" or be empty. Automagically fixing the URI.

This is a mirror of [this issue on d.o](https://www.drupal.org/project/search_api_pantheon/issues/3261858).