### PR TITLE
[BUGS-6560]: tag branches

### DIFF
--- a/.github/workflows/create-branch-on-tag.yml
+++ b/.github/workflows/create-branch-on-tag.yml
@@ -24,13 +24,14 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
           if_key_exists: ignore
-
       - name: Extract tag name
         id: tag_name
         run: |
           FULL_TAG=${GITHUB_REF#refs/tags/}
           MAJOR_MINOR="$(echo $FULL_TAG | cut -d '.' -f 1,2).x"
-          echo "::set-output name=BRANCH_NAME::$MAJOR_MINOR"
+          MAJOR_ONLY="$(echo $FULL_TAG | cut -d '.' -f 1).x"
+          echo "BRANCH_NAME=$MAJOR_MINOR" >> $GITHUB_OUTPUT
+          echo "MAJOR_BRANCH_NAME=$MAJOR_ONLY" >> $GITHUB_OUTPUT
       - name: Check if branch exists
         id: check_branch
         run: |
@@ -38,7 +39,6 @@ jobs:
           branch_existence=$(git ls-remote --heads origin ${{ steps.tag_name.outputs.BRANCH_NAME }})
           if [[ -z ${branch_existence} ]]; then
             echo "Branch for tag does not exist."
-            echo "::set-output name=exists::false"
             echo "exists=false" >> $GITHUB_OUTPUT
           else
             echo "Branch for tag already exists."
@@ -47,15 +47,14 @@ jobs:
       - name: Create branch
         if: steps.check_branch.outputs.exists == 'false'
         run: |
-          git checkout -b ${{ steps.tag_name.outputs.BRANCH_NAME }} origin/${{ github.event.repository.default_branch }}
+          git checkout -b ${{ steps.tag_name.outputs.BRANCH_NAME }} origin/${{ steps.tag_name.outputs.MAJOR_BRANCH_NAME }}
           git push origin ${{ steps.tag_name.outputs.BRANCH_NAME }}
-
       - name: Merge changes from current default branch
         if: steps.check_branch.outputs.exists == 'true'
         run: |
           git fetch
           git checkout -b ${{ steps.tag_name.outputs.BRANCH_NAME }} origin/${{ steps.tag_name.outputs.BRANCH_NAME }}
-          git merge origin/${{ github.event.repository.default_branch }}
+          git merge origin/${{ steps.tag_name.outputs.MAJOR_BRANCH_NAME }}
           git push origin HEAD:${{ steps.tag_name.outputs.BRANCH_NAME }}
       - name: Pushes to drupal.org repository
         run: |

--- a/.github/workflows/create-branch-on-tag.yml
+++ b/.github/workflows/create-branch-on-tag.yml
@@ -1,0 +1,42 @@
+name: Create Branch on Tag Push
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  create-branch:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'pantheon-systems/search_api_pantheon' }}
+    env:
+      BRANCH: ${{ github.ref_name }}
+      WORKSPACE: ${{ github.workspace }}
+      DRUPAL_ORG_REMOTE: ${{ secrets.DRUPAL_ORG_REMOTE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+          if_key_exists: ignore
+
+      - name: Extract tag name
+        id: tag_name
+        run: |
+          FULL_TAG=${GITHUB_REF#refs/tags/}
+          MAJOR_MINOR=$(echo $FULL_TAG | cut -d '.' -f 1,2)
+          echo "::set-output name=BRANCH_NAME::$MAJOR_MINOR"
+      - name: Create branch from tag
+        run: git branch ${{ steps.tag_name.outputs.BRANCH_NAME }} ${{ github.ref }} && git push origin ${{ steps.tag_name.outputs.BRANCH_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pushes to drupal.org repository
+        run: |
+          cd $WORKSPACE
+          git remote add drupalorg $DRUPAL_ORG_REMOTE
+          git push drupalorg $BRANCH_NAME

--- a/.github/workflows/create-branch-on-tag.yml
+++ b/.github/workflows/create-branch-on-tag.yml
@@ -29,7 +29,7 @@ jobs:
         id: tag_name
         run: |
           FULL_TAG=${GITHUB_REF#refs/tags/}
-          MAJOR_MINOR=$(echo $FULL_TAG | cut -d '.' -f 1,2)
+          MAJOR_MINOR="$(echo $FULL_TAG | cut -d '.' -f 1,2).x"
           echo "::set-output name=BRANCH_NAME::$MAJOR_MINOR"
       - name: Check if branch exists
         id: check_branch

--- a/.github/workflows/create-branch-on-tag.yml
+++ b/.github/workflows/create-branch-on-tag.yml
@@ -31,10 +31,32 @@ jobs:
           FULL_TAG=${GITHUB_REF#refs/tags/}
           MAJOR_MINOR=$(echo $FULL_TAG | cut -d '.' -f 1,2)
           echo "::set-output name=BRANCH_NAME::$MAJOR_MINOR"
-      - name: Create branch from tag
-        run: git branch ${{ steps.tag_name.outputs.BRANCH_NAME }} ${{ github.ref }} && git push origin ${{ steps.tag_name.outputs.BRANCH_NAME }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if branch exists
+        id: check_branch
+        run: |
+          git fetch
+          branch_existence=$(git ls-remote --heads origin ${{ steps.tag_name.outputs.BRANCH_NAME }})
+          if [[ -z ${branch_existence} ]]; then
+            echo "Branch for tag does not exist."
+            echo "::set-output name=exists::false"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          else
+            echo "Branch for tag already exists."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Create branch
+        if: steps.check_branch.outputs.exists == 'false'
+        run: |
+          git checkout -b ${{ steps.tag_name.outputs.BRANCH_NAME }} origin/${{ github.event.repository.default_branch }}
+          git push origin ${{ steps.tag_name.outputs.BRANCH_NAME }}
+
+      - name: Merge changes from current default branch
+        if: steps.check_branch.outputs.exists == 'true'
+        run: |
+          git fetch
+          git checkout -b ${{ steps.tag_name.outputs.BRANCH_NAME }} origin/${{ steps.tag_name.outputs.BRANCH_NAME }}
+          git merge origin/${{ github.event.repository.default_branch }}
+          git push origin HEAD:${{ steps.tag_name.outputs.BRANCH_NAME }}
       - name: Pushes to drupal.org repository
         run: |
           cd $WORKSPACE

--- a/.github/workflows/create-branch-on-tag.yml
+++ b/.github/workflows/create-branch-on-tag.yml
@@ -60,4 +60,4 @@ jobs:
         run: |
           cd $WORKSPACE
           git remote add drupalorg $DRUPAL_ORG_REMOTE
-          git push drupalorg $BRANCH_NAME
+          git push drupalorg HEAD:${{ steps.tag_name.outputs.BRANCH_NAME }}


### PR DESCRIPTION
Per request in https://getpantheon.atlassian.net/browse/BUGS-6560, whenever a new tag (ex: 1.2.3) is pushed to the repo, if a branch 1.2.x does not yet exist, that branch will be created. If the branch does exist, then the branch will be updated with the most recent commits from the corresponding major version branch 1.x.

Action testing was done on a fork which can be found here: https://github.com/rwagner00/search_api_pantheon/actions
Testing was done there to avoid any potential for a workflow under development to deploy something it ought not.