### PR TITLE
WIP: Experimental hack for DDev

### DIFF
--- a/src/Services/PantheonGuzzle.php
+++ b/src/Services/PantheonGuzzle.php
@@ -167,7 +167,18 @@ class PantheonGuzzle extends Client implements
         return !empty($item);
     });
     $uri = $uri->withPath('/' . ltrim(implode('/', $path_parts), '/'));
-    return $request->withUri($uri);
+
+    // This is an experimental hack to get Solr + DDev working.
+    // Some calls to Solr do not include the name of the core in the URL.
+    // I don't know why some do and some don't.
+    // But the errors seem to go away when the core name is included.
+    $path = $uri->getPath();
+   //if the $uri path contains /solr but not /solr/dev then replace /solr with /solr/dev
+    if (!isset($_ENV['PANTHEON_ENVIRONMENT']) && strpos($path, '/solr') !== FALSE && strpos($path, '/solr/dev') === FALSE) {
+       $uri = $uri->withPath(str_replace('/solr', '/solr/dev', $path));
+    }
+    
+    return $request->withUri($uri);    
   }
 
 }


### PR DESCRIPTION
I did some co-working today with @stovak and @jazzsequence trying to work out #181. We found that some requests from Drupal to Solr included the name of the core in the path of the request and some did not. (We did this by toggling `debug` property here: https://github.com/pantheon-systems/search_api_pantheon/blob/8.x/src/Services/PantheonGuzzle.php#L63)

Those that did not were 404s, those that did were 200s. So here's a hacky re-insertion of the core name that at least gets rid of the error in #181.
 
<img width="1162" alt="Screenshot 2024-07-18 at 9 48 59 PM" src="https://github.com/user-attachments/assets/762dbcc6-8c5c-4b8d-9af7-3d8ee1a1cdeb">


Someone with a better understanding of Solr than me could do more to explain. If I kept going, I'd stop comparing search_api_pantheon on a Pantheon multidev to search_api_pantheon on DDev and instead do a DDev to DDev comparison. I bet DDev works fine with regular search_api_solr.