### PR TITLE
[Jeli 93] Fix fatal error on "Post Schema" page

### DIFF
--- a/modules/search_api_pantheon_admin/src/Form/PantheonSolrAdminForm.php
+++ b/modules/search_api_pantheon_admin/src/Form/PantheonSolrAdminForm.php
@@ -80,7 +80,7 @@ class PantheonSolrAdminForm extends FormBase {
             '#weight' => substr($filename, 0, -3) === 'xml' ? -10 : 10,
         ];
 
-      if ( ! is_string($file_contents)) {
+      if (is_object($file_contents)) {
         $file_contents = json_encode($file_contents);
       }
       $form[$filename][] = $this->getViewSolrFile($filename, $file_contents, $is_open);

--- a/modules/search_api_pantheon_admin/src/Form/PantheonSolrAdminForm.php
+++ b/modules/search_api_pantheon_admin/src/Form/PantheonSolrAdminForm.php
@@ -79,6 +79,10 @@ class PantheonSolrAdminForm extends FormBase {
             '#group' => 'status',
             '#weight' => substr($filename, 0, -3) === 'xml' ? -10 : 10,
         ];
+
+      if ( ! is_string($file_contents)) {
+        $file_contents = json_encode($file_contents);
+      }
       $form[$filename][] = $this->getViewSolrFile($filename, $file_contents, $is_open);
       $is_open = FALSE;
     }


### PR DESCRIPTION
Following deploying #195, the response from the solr server changed now that config was being written to disk as part of the reload core. This changed the behavior of `pantheonGuzzle->getQueryResult` in certain cases which resulted in a fatal error at `/admin/config/search/search-api/server/pantheon_solr8/pantheon-admin`.

