### PR TITLE
Drupal 11 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,8 @@
         "http-interop/http-factory-guzzle": "^1.0",
         "kint-php/kint": "^4.1|^5",
         "psr/event-dispatcher": "^1.0",
-        "symfony/finder": "^4.4|^5|^6",
-        "symfony/yaml": "^4.4|^5|^6"
+        "symfony/finder": "^4.4|^5|^6|^7",
+        "symfony/yaml": "^4.4|^5|^6|^7"
     },
     "require-dev": {
         "consolidation/robo": "^3.0",

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,26 +1,26 @@
 services:
   search_api_pantheon.drush_diagnose:
     class: \Drupal\search_api_pantheon\Commands\Diagnose
-    arguments: [ "@logger.factory", "@search_api_pantheon.pantheon_guzzle", "@search_api_pantheon.endpoint", "@search_api_pantheon.solarium_client" ]
+    arguments: [ "@search_api_pantheon.pantheon_guzzle", "@search_api_pantheon.endpoint", "@search_api_pantheon.solarium_client" ]
     tags:
       - { name: drush.command }
   search_api_pantheon.drush_test_index_and_query:
     class: \Drupal\search_api_pantheon\Commands\TestIndexAndQuery
-    arguments: [ "@logger.factory", "@search_api_pantheon.pantheon_guzzle", "@search_api_pantheon.endpoint", "@search_api_pantheon.solarium_client" ]
+    arguments: [ "@search_api_pantheon.pantheon_guzzle", "@search_api_pantheon.endpoint", "@search_api_pantheon.solarium_client" ]
     tags:
       - { name: drush.command }
   search_api_pantheon.drush_schema:
     class: \Drupal\search_api_pantheon\Commands\Schema
-    arguments: [ "@logger.factory", "@search_api_pantheon.pantheon_guzzle", "@search_api_pantheon.schema_poster" ]
+    arguments: [ "@search_api_pantheon.pantheon_guzzle", "@search_api_pantheon.schema_poster" ]
     tags:
       - { name: drush.command }
   search_api_pantheon.drush_query:
     class: \Drupal\search_api_pantheon\Commands\Query
-    arguments: [ "@logger.factory", "@search_api_pantheon.pantheon_guzzle", "@search_api_pantheon.endpoint", "@search_api_pantheon.solarium_client" ]
+    arguments: [ "@search_api_pantheon.pantheon_guzzle", "@search_api_pantheon.endpoint", "@search_api_pantheon.solarium_client" ]
     tags:
       - { name: drush.command }
   search_api_pantheon.drush_reload:
     class: \Drupal\search_api_pantheon\Commands\Reload
-    arguments: [ "@logger.factory", "@search_api_pantheon.pantheon_guzzle", "@search_api_pantheon.schema_poster" ]
+    arguments: [ "@search_api_pantheon.pantheon_guzzle", "@search_api_pantheon.schema_poster" ]
     tags:
       - { name: drush.command }

--- a/modules/search_api_pantheon_admin/search_api_pantheon_admin.info.yml
+++ b/modules/search_api_pantheon_admin/search_api_pantheon_admin.info.yml
@@ -1,7 +1,7 @@
 name: Search API Pantheon Admin
 type: module
 description: Administer a Pantheon Search server
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^9.4 || ^10 || ^11
 package: Search
 dependencies:
   - search_api_solr:search_api_solr

--- a/modules/search_api_pantheon_examples/search_api_pantheon_examples.info.yml
+++ b/modules/search_api_pantheon_examples/search_api_pantheon_examples.info.yml
@@ -1,7 +1,7 @@
 name: Search API Pantheon Examples
 type: module
 description: Contains some examples of things you could do with Search API Pantheon module. This module should not be enabled in prod.
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^9.4 || ^10 || ^11
 package: Search
 dependencies:
   - search_api_pantheon:search_api_pantheon

--- a/search_api_pantheon.info.yml
+++ b/search_api_pantheon.info.yml
@@ -1,7 +1,7 @@
 name: Search API Pantheon
 type: module
 description: Search API + Solr + Pantheon integration
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^9.4 || ^10 || ^11
 package: Search
 dependencies:
   - search_api_solr:search_api_solr

--- a/src/Commands/Diagnose.php
+++ b/src/Commands/Diagnose.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\search_api_pantheon\Commands;
 
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\search_api_pantheon\Services\Endpoint;
 use Drupal\search_api_pantheon\Services\PantheonGuzzle;
 use Drupal\search_api_pantheon\Services\SolariumClient;
@@ -31,8 +30,6 @@ class Diagnose extends DrushCommands {
   /**
    * Class Constructor.
    *
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerChannelFactory
-   *   Injected by container.
    * @param \Drupal\search_api_pantheon\Services\PantheonGuzzle $pantheonGuzzle
    *   Injected by container.
    * @param \Drupal\search_api_pantheon\Services\Endpoint $endpoint
@@ -41,12 +38,10 @@ class Diagnose extends DrushCommands {
    *   Injected by container.
    */
   public function __construct(
-        LoggerChannelFactoryInterface $loggerChannelFactory,
         PantheonGuzzle $pantheonGuzzle,
         Endpoint $endpoint,
         SolariumClient $solariumClient
     ) {
-    $this->logger = $loggerChannelFactory->get('SearchAPIPantheon Drush');
     $this->pantheonGuzzle = $pantheonGuzzle;
     $this->endpoint = $endpoint;
     $this->solr = $solariumClient;

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\search_api_pantheon\Commands;
 
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\search_api_pantheon\Services\Endpoint;
 use Drupal\search_api_pantheon\Services\PantheonGuzzle;
 use Drupal\search_api_pantheon\Services\SolariumClient;
@@ -30,8 +29,6 @@ class Query extends DrushCommands {
   /**
    * Class Constructor.
    *
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerChannelFactory
-   *   Injected by container.
    * @param \Drupal\search_api_pantheon\Services\PantheonGuzzle $pantheonGuzzle
    *   Injected by container.
    * @param \Drupal\search_api_pantheon\Services\Endpoint $endpoint
@@ -40,12 +37,10 @@ class Query extends DrushCommands {
    *   Injected by container.
    */
   public function __construct(
-        LoggerChannelFactoryInterface $loggerChannelFactory,
         PantheonGuzzle $pantheonGuzzle,
         Endpoint $endpoint,
         SolariumClient $solariumClient
     ) {
-    $this->logger = $loggerChannelFactory->get('SearchAPIPantheon Drush');
     $this->pantheonGuzzle = $pantheonGuzzle;
     $this->endpoint = $endpoint;
     $this->solr = $solariumClient;

--- a/src/Commands/Reload.php
+++ b/src/Commands/Reload.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\search_api_pantheon\Commands;
 
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelTrait;
 use Drupal\search_api_pantheon\Services\PantheonGuzzle;
 use Drupal\search_api_pantheon\Services\SchemaPoster;
@@ -12,7 +11,6 @@ use Drush\Commands\DrushCommands;
  * Drush Search Api Pantheon Schema Commands.
  */
 class Reload extends DrushCommands {
-  use LoggerChannelTrait;
 
   /**
    * Configured pantheon-solr-specific guzzle client.
@@ -31,19 +29,15 @@ class Reload extends DrushCommands {
   /**
    * Class constructor.
    *
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerChannelFactory
-   *   Injected by container.
    * @param \Drupal\search_api_pantheon\Services\PantheonGuzzle $pantheonGuzzle
    *   Injected by container.
    * @param \Drupal\search_api_pantheon\Services\SchemaPoster $schemaPoster
    *   Injected by Container.
    */
   public function __construct(
-        LoggerChannelFactoryInterface $loggerChannelFactory,
         PantheonGuzzle $pantheonGuzzle,
         SchemaPoster $schemaPoster
     ) {
-    $this->logger = $loggerChannelFactory->get('SearchAPIPantheon Drush');
     $this->pantheonGuzzle = $pantheonGuzzle;
     $this->schemaPoster = $schemaPoster;
   }

--- a/src/Commands/Schema.php
+++ b/src/Commands/Schema.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\search_api_pantheon\Commands;
 
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelTrait;
 use Drupal\search_api_pantheon\Plugin\SolrConnector\PantheonSolrConnector;
 use Drupal\search_api_pantheon\Services\PantheonGuzzle;
@@ -14,7 +13,6 @@ use Symfony\Component\Finder\Finder;
  * Drush Search Api Pantheon Schema Commands.
  */
 class Schema extends DrushCommands {
-  use LoggerChannelTrait;
 
   /**
    * Configured pantheon-solr-specific guzzle client.
@@ -33,19 +31,15 @@ class Schema extends DrushCommands {
   /**
    * Class constructor.
    *
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerChannelFactory
-   *   Injected by container.
    * @param \Drupal\search_api_pantheon\Services\PantheonGuzzle $pantheonGuzzle
    *   Injected by container.
    * @param \Drupal\search_api_pantheon\Services\SchemaPoster $schemaPoster
    *   Injected by Container.
    */
   public function __construct(
-        LoggerChannelFactoryInterface $loggerChannelFactory,
         PantheonGuzzle $pantheonGuzzle,
         SchemaPoster $schemaPoster
     ) {
-    $this->logger = $loggerChannelFactory->get('SearchAPIPantheon Drush');
     $this->pantheonGuzzle = $pantheonGuzzle;
     $this->schemaPoster = $schemaPoster;
   }

--- a/src/Commands/TestIndexAndQuery.php
+++ b/src/Commands/TestIndexAndQuery.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\search_api_pantheon\Commands;
 
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\search_api_pantheon\Services\Endpoint;
 use Drupal\search_api_pantheon\Services\PantheonGuzzle;
 use Drupal\search_api_pantheon\Services\SolariumClient;
@@ -35,8 +34,6 @@ class TestIndexAndQuery extends DrushCommands {
   /**
    * Class Constructor.
    *
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerChannelFactory
-   *   Injected by container.
    * @param \Drupal\search_api_pantheon\Services\PantheonGuzzle $pantheonGuzzle
    *   Injected by container.
    * @param \Drupal\search_api_pantheon\Services\Endpoint $endpoint
@@ -45,12 +42,10 @@ class TestIndexAndQuery extends DrushCommands {
    *   Injected by container.
    */
   public function __construct(
-    LoggerChannelFactoryInterface $loggerChannelFactory,
     PantheonGuzzle $pantheonGuzzle,
     Endpoint $endpoint,
     SolariumClient $solariumClient
   ) {
-    $this->logger = $loggerChannelFactory->get('SearchAPIPantheon Drush');
     $this->pantheonGuzzle = $pantheonGuzzle;
     $this->endpoint = $endpoint;
     $this->solr = $solariumClient;

--- a/src/Services/SolariumClient.php
+++ b/src/Services/SolariumClient.php
@@ -10,7 +10,7 @@ use Solarium\Core\Query\QueryInterface;
 use Solarium\Core\Query\Result\ResultInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\search_api_pantheon\Solarium\EventDispatcher\Psr14Bridge;
-use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * Customized Solrium Client to send Guzzle debugging to log entries.
@@ -21,7 +21,7 @@ class SolariumClient extends Client {
   /**
    * Class constructor.
    */
-  public function __construct(PantheonGuzzle $guzzle, Endpoint $endpoint, LoggerChannelFactoryInterface $logger_factory, ContainerAwareEventDispatcher $event_dispatcher) {
+  public function __construct(PantheonGuzzle $guzzle, Endpoint $endpoint, LoggerChannelFactoryInterface $logger_factory, EventDispatcher $event_dispatcher) {
     $drupal_major_parts = explode('.', \Drupal::VERSION);
     $drupal_major = reset($drupal_major_parts);
     if ($drupal_major < 9) {


### PR DESCRIPTION
- Upgrade dependencies
- Do not override drush logger (causes fatal error)
- Use Symfony EventDispatcher instead of deprecated Drupal ContainerAwareEventDispatcher