### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -207,7 +207,7 @@ class RoboFile extends Tasks {
       else {
         // Maybe we are on a PR.
         $branch = $_SERVER['GITHUB_HEAD_REF'];
-        $branch_parts = explode('/', $branch);
+        $branch_parts = explode('/', (string) $branch);
         $branch = end($branch_parts);
         if ($branch) {
           return "{$branch}-dev";
@@ -318,7 +318,7 @@ class RoboFile extends Tasks {
   private function cleanUpInfo(array $info): array {
     // Clean up the workflow status data and assign values to an array so it's easier to check.
     foreach ($info as $line => $value) {
-      $ln = array_values(array_filter(explode("  ", trim($value))));
+      $ln = array_values(array_filter(explode("  ", trim((string) $value))));
 
       // Skip lines with only one value. This filters out the ASCII dividers output by the command.
       if (count($ln) > 1) {
@@ -752,9 +752,7 @@ class RoboFile extends Tasks {
         return $result;
       }
     }
-    catch (\Exception $e) {
-    }
-    catch (\Throwable $t) {
+    catch (\Exception|\Throwable $e) {
     }
     return NULL;
   }

--- a/modules/search_api_pantheon_admin/src/Form/PantheonSolrAdminForm.php
+++ b/modules/search_api_pantheon_admin/src/Form/PantheonSolrAdminForm.php
@@ -33,6 +33,7 @@ class PantheonSolrAdminForm extends FormBase {
   /**
    * {@inheritdoc}
    */
+  #[\Override]
   public static function create(ContainerInterface $container) {
     return new static(
           $container->get('search_api_pantheon.pantheon_guzzle'),
@@ -75,9 +76,9 @@ class PantheonSolrAdminForm extends FormBase {
         ]);
       $form[$filename] = [
             '#type' => 'details',
-            '#title' => ucwords($filename),
+            '#title' => ucwords((string) $filename),
             '#group' => 'status',
-            '#weight' => substr($filename, 0, -3) === 'xml' ? -10 : 10,
+            '#weight' => substr((string) $filename, 0, -3) === 'xml' ? -10 : 10,
         ];
 
       if (is_array($file_contents)) {

--- a/modules/search_api_pantheon_admin/src/Form/PostSolrSchema.php
+++ b/modules/search_api_pantheon_admin/src/Form/PostSolrSchema.php
@@ -40,6 +40,7 @@ class PostSolrSchema extends FormBase {
   /**
    * {@inheritdoc}
    */
+  #[\Override]
   public static function create(ContainerInterface $container) {
     return new static(
           $container->get('search_api_pantheon.schema_poster'),
@@ -82,6 +83,7 @@ class PostSolrSchema extends FormBase {
   /**
    * {@inheritdoc}
    */
+  #[\Override]
   public function validateForm(array &$form, FormStateInterface $form_state) {
     $path = $form_state->getValue('path');
     if ($path) {
@@ -131,7 +133,7 @@ class PostSolrSchema extends FormBase {
       return $functions[$type];
     }
 
-    $this->messenger()->addWarning(t('Unknown message type: @type', ['@type' => $message[0]]));
+    $this->messenger()->addWarning(t('Unknown message type: @type', ['@type' => $type]));
     return 'addStatus';
   }
 

--- a/modules/search_api_pantheon_examples/search_api_pantheon_examples.module
+++ b/modules/search_api_pantheon_examples/search_api_pantheon_examples.module
@@ -16,7 +16,7 @@ function search_api_pantheon_examples_search_api_solr_config_files_alter(array &
 
   // Use PHP's DOM API to modify the XML files.
   $schema_xml = &$files['schema.xml'];
-  if ($schema_xml_dom = \DomDocument::loadXML($schema_xml)) {
+  if ($schema_xml_dom = (new \DomDocument())->loadXML($schema_xml)) {
     $fields = $schema_xml_dom->getElementsByTagName('field');
     foreach ($fields as $field) {
       if ($field->hasAttribute('name') && $field->getAttribute('name') === 'hash') {

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -77,8 +77,8 @@ class Query extends DrushCommands {
   ]) {
     $this->logger->notice('Running a select query against Pantheon Solr.');
 
-    $this->logger->notice('Query: ' . urldecode($query));
-    $options['query'] = urldecode($query);
+    $this->logger->notice('Query: ' . urldecode((string) $query));
+    $options['query'] = urldecode((string) $query);
 
     $query_object = $this->solr->createSelect($options);
     $query_object->setResponseWriter($options['wt']);

--- a/src/EventSubscriber/SearchApiPantheonSolrConfigFilesAlter.php
+++ b/src/EventSubscriber/SearchApiPantheonSolrConfigFilesAlter.php
@@ -25,7 +25,7 @@ final class SearchApiPantheonSolrConfigFilesAlter implements EventSubscriberInte
     $files = $event->getConfigFiles();
 
     // Append at the end of the file.
-    $solrcore_properties = explode(PHP_EOL, $files['solrcore.properties']);
+    $solrcore_properties = explode(PHP_EOL, (string) $files['solrcore.properties']);
     // Remove the solr.install.dir if it exists
     foreach ($solrcore_properties as $key => $property) {
       if (substr($property, 0, 16) == 'solr.install.dir') {
@@ -49,7 +49,7 @@ final class SearchApiPantheonSolrConfigFilesAlter implements EventSubscriberInte
    */
   public static function getSubscribedEvents(): array {
     return [
-      'Drupal\search_api_solr\Event\PostConfigFilesGenerationEvent' => ['onPostConfigFilesGenerationEvent'],
+      PostConfigFilesGenerationEvent::class => ['onPostConfigFilesGenerationEvent'],
     ];
   }
 

--- a/src/Plugin/SolrConnector/PantheonSolrConnector.php
+++ b/src/Plugin/SolrConnector/PantheonSolrConnector.php
@@ -98,6 +98,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
    * @return \Drupal\search_api\Plugin\ConfigurablePluginBase|\Drupal\search_api_pantheon\Plugin\SolrConnector\PantheonSolrConnector|static
    * @throws \Exception
    */
+  #[\Override]
   public static function create(
     ContainerInterface $container,
     array $configuration,
@@ -145,6 +146,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
   /**
    * @return array
    */
+  #[\Override]
   public function defaultConfiguration() {
     return array_merge(
       parent::defaultConfiguration(),
@@ -167,6 +169,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
    * @return array
    *   Form render array.
    */
+  #[\Override]
   public function buildConfigurationForm(
     array $form,
     FormStateInterface $form_state
@@ -205,6 +208,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   Form state object.
    */
+  #[\Override]
   public function validateConfigurationForm(
     array &$form,
     FormStateInterface $form_state
@@ -219,6 +223,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   Form state object.
    */
+  #[\Override]
   public function submitConfigurationForm(
     array &$form,
     FormStateInterface $form_state
@@ -235,6 +240,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
+  #[\Override]
   public function adjustTimeout(int $seconds, string $timeout = self::QUERY_TIMEOUT, ?Endpoint &$endpoint = NULL): int {
     $this->connect();
 
@@ -265,6 +271,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
    *
    * @throws \JsonException
    */
+  #[\Override]
   public function getStatsSummary() {
     $stats = [];
     try {
@@ -339,6 +346,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
   /**
    * {@inheritdoc}
    */
+  #[\Override]
   public function useTimeout(
     string $timeout = self::QUERY_TIMEOUT,
     ?Endpoint $endpoint = NULL
@@ -350,6 +358,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
    *
    * @throws \Drupal\search_api_solr\SearchApiSolrException
    */
+  #[\Override]
   public function viewSettings() {
     $view_settings = [];
 
@@ -370,7 +379,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
     foreach ($core_info['core'] as $key => $value) {
       if (is_string($value)) {
         $view_settings[] = [
-          'label' => ucwords($key),
+          'label' => ucwords((string) $key),
           'info' => $value,
         ];
       }
@@ -388,6 +397,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
    * @return \Solarium\Core\Client\Endpoint
    *   The endpoint in question.
    */
+  #[\Override]
   public function getEndpoint($key = 'search_api_solr') {
     return $this->solr->getEndpoint();
   }
@@ -406,6 +416,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
   /**
    * {@inheritdoc}
    */
+  #[\Override]
   public function getFile($file = NULL) {
     $query = [
       'action' => 'VIEW',
@@ -422,6 +433,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
   /**
    * {@inheritdoc}
    */
+  #[\Override]
   public function getServerInfo($reset = FALSE) {
     return $this->getDataFromHandler($this->configuration['core'] . '/admin/system', $reset);
   }
@@ -429,6 +441,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
   /**
    * Prepares the connection to the Solr server.
    */
+  #[\Override]
   protected function connect() {
     if (!$this->solr instanceof SolariumClient) {
       $config = $this->defaultConfiguration();
@@ -443,6 +456,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
    *
    * @return object|\Solarium\Client|null
    */
+  #[\Override]
   protected function createClient(array &$configuration) {
     return $this->solariumClient;
   }

--- a/src/Services/Endpoint.php
+++ b/src/Services/Endpoint.php
@@ -86,6 +86,7 @@ class Endpoint extends SolariumEndpoint {
    *
    * @throws \Solarium\Exception\UnexpectedValueException
    */
+  #[\Override]
   public function getCoreBaseUri(): string {
     return vsprintf(
       '%s%s%s/',
@@ -103,6 +104,7 @@ class Endpoint extends SolariumEndpoint {
    * @return string
    *   Base URL with scheme and port.
    */
+  #[\Override]
   public function getBaseUri(): string {
     return vsprintf(
       '%s://%s:%d/',
@@ -122,6 +124,7 @@ class Endpoint extends SolariumEndpoint {
    *
    * @throws \Solarium\Exception\UnexpectedValueException
    */
+  #[\Override]
   public function getV1BaseUri(): string {
     return isset($_ENV['PANTHEON_ENVIRONMENT'])
       ? 'v1' : '';
@@ -135,6 +138,7 @@ class Endpoint extends SolariumEndpoint {
    *
    * @throws \Solarium\Exception\UnexpectedValueException
    */
+  #[\Override]
   public function getV2BaseUri(): string {
     return $this->getBaseUri() . '/api/';
   }
@@ -145,6 +149,7 @@ class Endpoint extends SolariumEndpoint {
    * @return string
    *   Base URI for the endpoint.
    */
+  #[\Override]
   public function getServerUri(): string {
     return $this->getBaseUri();
   }
@@ -253,6 +258,7 @@ class Endpoint extends SolariumEndpoint {
    * @return string|null
    *   Always use the default name.
    */
+  #[\Override]
   public function getKey(): ?string {
     return self::DEFAULT_NAME;
   }

--- a/src/Services/PantheonGuzzle.php
+++ b/src/Services/PantheonGuzzle.php
@@ -98,6 +98,7 @@ class PantheonGuzzle extends Client implements
    *
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
+  #[\Override]
   public function sendRequest(RequestInterface $request): ResponseInterface {
     return $this->send($request);
   }
@@ -154,10 +155,10 @@ class PantheonGuzzle extends Client implements
     $shouldBeInUrl = $this->endpoint->getMySitename();
     $shouldBeInPath = $this->endpoint->getPath();
     if (!in_array(trim($shouldBeInUrl, '/'), $path_parts)) {
-      array_unshift($path_parts, trim($this->endpoint->getCore(), '/'));
+      array_unshift($path_parts, trim((string) $this->endpoint->getCore(), '/'));
     }
-    if (!in_array(trim($shouldBeInPath, '/'), $path_parts)) {
-      array_unshift($path_parts, trim($this->endpoint->getPath(), '/'));
+    if (!in_array(trim((string) $shouldBeInPath, '/'), $path_parts)) {
+      array_unshift($path_parts, trim((string) $this->endpoint->getPath(), '/'));
     }
     $path_parts = array_filter($path_parts, function ($item) {
         return !empty($item);

--- a/src/Services/SchemaPoster.php
+++ b/src/Services/SchemaPoster.php
@@ -183,7 +183,7 @@ class SchemaPoster implements LoggerAwareInterface {
         ]);
       $toSend['files'][] = [
             'filename' => $filename,
-            'content' => base64_encode($file_contents),
+            'content' => base64_encode((string) $file_contents),
         ];
     }
 

--- a/src/Services/SolariumClient.php
+++ b/src/Services/SolariumClient.php
@@ -44,6 +44,7 @@ class SolariumClient extends Client {
    *
    * @return \Solarium\Core\Query\Result\ResultInterface
    */
+  #[\Override]
   public function execute(QueryInterface $query, $endpoint = NULL): ResultInterface {
     return parent::execute($query, $this->defaultEndpoint);
   }
@@ -56,6 +57,7 @@ class SolariumClient extends Client {
    *
    * @return \Solarium\Core\Client\Response
    */
+  #[\Override]
   public function executeRequest(Request $request, $endpoint = NULL): Response {
     return parent::executeRequest($request, $this->defaultEndpoint);
   }

--- a/src/Solarium/EventDispatcher/EventProxy.php
+++ b/src/Solarium/EventDispatcher/EventProxy.php
@@ -17,10 +17,12 @@ class EventProxy extends Event {
     $this->event = $event;
   }
 
+  #[\Override]
   public function isPropagationStopped() {
     return $this->event->isPropagationStopped();
   }
 
+  #[\Override]
   public function stopPropagation() {
     $this->event->stopPropagation();
   }

--- a/tests/Unit/GuzzleClassTest.php
+++ b/tests/Unit/GuzzleClassTest.php
@@ -27,13 +27,9 @@ class GuzzleClassTest extends TestCase {
   protected function setUp(): void {
     parent::setUp();
 
-    $logger = $this->getMockBuilder(LoggerInterface::class)
-      ->disableOriginalConstructor()
-      ->getMock();
+    $logger = $this->createMock(LoggerInterface::class);
 
-    $this->loggerFactory = $this->getMockBuilder(LoggerChannelFactoryInterface::class)
-      ->disableOriginalConstructor()
-      ->getMock();
+    $this->loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
 
     $this->loggerFactory
       ->expects($this->any())

--- a/tests/Unit/SchemaPosterTest.php
+++ b/tests/Unit/SchemaPosterTest.php
@@ -33,13 +33,9 @@ class SchemaPosterTest extends TestCase {
   protected function setUp(): void {
     parent::setUp();
 
-    $logger = $this->getMockBuilder(LoggerInterface::class)
-      ->disableOriginalConstructor()
-      ->getMock();
+    $logger = $this->createMock(LoggerInterface::class);
 
-    $this->loggerFactory = $this->getMockBuilder(LoggerChannelFactoryInterface::class)
-      ->disableOriginalConstructor()
-      ->getMock();
+    $this->loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
 
     $this->loggerFactory
       ->expects($this->any())


### PR DESCRIPTION
Rector have not found anything but fixes for "PHP 8.1 has deprecated passing null as a parameter to a lot of core functions".  It's possible there's more casting than strictly necessary but casting doesn't hurt. 

The fix in `getMessageFunction` is a bit of a guesswork but it's a very educated guesswork: this has been split from `submitForm` and the variable name was not corrected.

This is the rector config adopted from https://github.com/rectorphp/rector/discussions/8285#discussioncomment-11239164 with two PHP 7 rules added on top -- they are not necessary and I wanted to keep changes to a minimum. I made an exception with the `Override` attribute: while it is not necessary but attributes are completely harmless as they are parsed as comments in PHP versions not recognizing attributes and so I left those.

```
    $rectorConfig->sets([
        Drupal8SetList::DRUPAL_8,
        Drupal9SetList::DRUPAL_9,
        Drupal10SetList::DRUPAL_10,
        LevelSetList::UP_TO_PHP_84,
    ]);
$rectorConfig->skip([
        \Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector::class,
        \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
        \Rector\Php80\Rector\FunctionLike\MixedTypeRector::class,
        \Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector::class,
        \Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector::class,
        \Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class,
        \Rector\Php80\Rector\NotIdentical\StrContainsRector::class,
        \Rector\Php80\Rector\Identical\StrStartsWithRector::class,
        \Rector\Php80\Rector\Identical\StrEndsWithRector::class,
        \Rector\Php80\Rector\FuncCall\ClassOnObjectRector::class,
        \Rector\Php80\Rector\ClassConstFetch\ClassOnThisVariableObjectRector::class,
        \Rector\Php81\Rector\Array_\FirstClassCallableRector::class,
        \Rector\Php81\Rector\ClassMethod\NewInInitializerRector::class,
        \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
        \Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector::class,
        \Rector\Arguments\Rector\FuncCall\FunctionArgumentDefaultValueReplacerRector::class,
    ]);
```
