### PR TITLE
[WIP]Add fix to migrate pantheon_solr8 search server to pantheon_search

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,20 +1,32 @@
+
+Search API Pantheon 8.3.3
+--------------------------------------------------
+- Bug fix #3505065: Migrated search server ID from 'pantheon_solr8' to 'pantheon_search'.
+
+### Upgrade Instructions
+If you are upgrading from version 8.2.x or earlier to 8.3.x, you must run database updates after the upgrade to complete the migration:
+
+- Run `drush updb` **or** visit '/update.php' in your browser.
+- This will migrate  server for all search indexes  from 'pantheon_solr8 'to 'pantheon_search' and delete the old 'pantheon_solr8' server.
+For new installations of version 8.3.x, no action is needed.
+
 Search API Patheon 8.3.0
 --------------------------------------------------
 - Compatible with Pantheon Search (Solr 8)
-- Compatible with Drupal 10.x
+- Compatible with Drupal 11.x
 - Versions of Drupal less than 10 are not supported.
 - Versions of PHP less than 8.1 are not supported
 
-Search API Patheon 8.x-8.x-alpha1
+Search API Pantheon 8.x-8.x-alpha1
 --------------------------------------------------
 - Compatible with Pantheon Search (Solr 8)
 - Compatible with Drupal 9.x
 
-Search API Patheon 8.x-1.x-alpha2
+Search API Pantheon 8.x-1.x-alpha2
 --------------------------------------------------
 - Issue #2818001 by stevector: Refactor for SolrConnector Plugin
 - Issue #2761831 by stevector: Update .gitattributes file
 
-Search API Patheon 8.x-1.x-alpha1
+Search API Pantheon 8.x-1.x-alpha1
 --------------------------------------------------
 - Issue #2821769 by stevector: Initial release. Compatible with Search API Solr alpha6.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
-# Search API Pantheon: Solr 8 & Drupal 9/10 Integration
+# Search API Pantheon: Solr 8 & Drupal 9/10/11 Integration
 
 [![Search API Pantheon](https://github.com/pantheon-systems/search_api_pantheon/actions/workflows/ci.yml/badge.svg?branch=8.x)](https://github.com/pantheon-systems/search_api_pantheon/actions/workflows/ci.yml)
 [![Limited Availability](https://img.shields.io/badge/Pantheon-Limited_Availability-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#limited-availability)
 
-## Important Notice - Schema Reversion Prevention
+## Important Notice
+
+** Search Server Migration (8.3.x)
+
+If you are upgrading from version 8.2.x or earlier to 8.3.x, you must run database updates after the upgrade to complete the migration:
+- Run `drush updb` or visit `/update.php` in your browser.
+- This will migrate all search indexes to the new `pantheon_search` server ID and delete the old `pantheon_solr8` server.
+
+For new installations of version 8.3.x, no action is needed.
+
+
+** Schema Reversion Prevention
 
 Starting with version 8.2, this module includes critical fixes to prevent Solr schema reversions that could cause:
 
@@ -18,7 +29,7 @@ Users experiencing these issues should upgrade immediately to version 8.1.x-dev.
 
 This module is for you if you meet the following requirements:
 
-- Using Drupal 9.4/10
+- Using Drupal 9.4/10/11
 - Hosting the Drupal site on Pantheon's platform
 - Your site uses `composer` to install modules and upgrade Drupal core using one of the following integrations:
 
@@ -35,7 +46,7 @@ Search API Solr provides the ability to connect to any Solr server by providing 
 
 ## What it provides
 
-This module provides [Drupal 9 and 10](https://drupal.org) integration with the [Apache Solr project](https://solr.apache.org/guide/8_8/). Pantheon's current version as of the update of this document is 8.11.4.
+This module provides [Drupal 9 -11](https://drupal.org) integration with the [Apache Solr project](https://solr.apache.org/guide/8_8/). Pantheon's current version as of the update of this document is 8.11.4.
 
 ## Composer
 
@@ -55,7 +66,7 @@ Composer is the way you should be managing your drupal module requirements. This
 To install this module via composer, run the following command in your Drupal root:
 
 ```bash
-composer require 'drupal/search_api_pantheon:^8.1'
+composer require 'drupal/search_api_pantheon:^8.3'
 ```
 
 ### Development Version

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -26,3 +26,39 @@ function search_api_pantheon_requirements($phase) {
 
   return $requirements;
 }
+
+/**
+ * Migrate  search server pantheon_solr8  to pantheon_search.
+ */
+function search_api_pantheon_update_8300() {
+  $config_factory = \Drupal::configFactory();
+  $server = $config_factory->getEditable('search_api.server.pantheon_solr8');
+  $logger = \Drupal::logger('search_api_pantheon');
+
+  if ($server->get('id')) {
+    $data = $server->getRawdata();
+    $data['id'] = 'pantheon_search';
+    $config_factory->getEditable('search_api.server.pantheon_search')
+      ->setData($data)
+      ->save();
+    $logger->info("Search server id changed from 'pantheon_solr8' to 'pantheon_search'");
+  }
+  else {
+    return;
+  }
+
+  // Replace  server id  for all indexes with  pantheon_search.
+  $indexes = \Drupal::entityTypeManager()->getStorage('search_api_index')->loadMultiple();
+  foreach ($indexes as $index) {
+    if ($index->get('server') === 'pantheon_solr8') {
+      $index->set('server', 'pantheon_search');
+      $index->save();
+      $logger->info('Updated  search server id for index @index to  pantheon_search.', ['@index' => $index->id()]);
+    }
+  }
+
+  // Delete the old search  server 'pantheon_solr8'.
+  if ($server->get('id')) {
+    $server->delete();
+  }
+}


### PR DESCRIPTION
When a user upgrade from Search API pantheon 8.2.x to 8.3.x  version 

- The update hook changes the search server ID from pantheon_solr8 to pantheon_search.
- All existing indexes currently configured with pantheon_solr8 as their search server will be migrated to pantheon_search.
- And then the old search  server with id 'pantheon_solr8' will be deleted.

Tested on Prod site.
