### PR TITLE
[BUGS-9875]  #2 Add fix for upgrading from earlier versions to 8.3.x

### DIFF
--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -93,10 +93,11 @@ function search_api_pantheon_update_8300() {
       $logger->info("Deleted old search server '$old_server_id'.");
     }
 
-  } catch (\Exception $e) {
+  }
+  catch (\Exception $e) {
     $logger->error('Error occurred during search server migration: @message. Please re-run database updates.', [
       '@message' => $e->getMessage(),
-    ]);
+     ]);
     throw $e;
   }
 }

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -26,3 +26,77 @@ function search_api_pantheon_requirements($phase) {
 
   return $requirements;
 }
+
+/**
+ * Updates search server and index configuration during module upgrade.
+ *
+ * This update hook assists in the transition when upgrading the
+ * module from earlier versions to 8.3.x.
+ * It updates the search server from 'pantheon_solr8' to 'pantheon_search',
+ * and updates 'Basic Content Index (content_index)' with  'Primary(primary)'
+ */
+function search_api_pantheon_update_8300() {
+  $old_server_id          = 'pantheon_solr8';
+  $new_server_id          = 'pantheon_search';
+  $old_index_id           = 'content_index';
+  $new_index_id           = 'primary';
+  $config_factory         = \Drupal::configFactory();
+  $pantheon_solr8_config  = $config_factory->getEditable("search_api.server.pantheon_solr8");
+  $pantheon_search_config = $config_factory->getEditable("search_api.server.pantheon_search");
+  $primary_index_config   = $config_factory->getEditable("search_api.index.primary");
+  $content_index_config   = $config_factory->getEditable("search_api.index.content_index");
+  $logger                 = \Drupal::logger('search_api_pantheon');
+
+  // Skip migration if 'pantheon_solr8' search server doesn't exist,
+  // or if both the 'pantheon_search' server and 'primary' index already exist.
+  if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew() && !$primary_index_config->isNew())) {
+    return;
+  }
+
+  try {
+    // Create the 'pantheon_search' server if it doesn't exist.
+    if ($pantheon_search_config->isNew()) {
+      $data = $pantheon_solr8_config->getRawData();
+      $data['id'] = $new_server_id;
+      $pantheon_search_config->setData($data)->save();
+      $logger->info("Search server ID changed from '$old_server_id' to '$new_server_id'.");
+    }
+
+    // Update all search indexes with 'pantheon_solr8' as search server to 'pantheon_search'
+    $indexes = \Drupal::entityTypeManager()->getStorage('search_api_index')->loadMultiple();
+    foreach ($indexes as $index) {
+      if ($index->get('server') === $old_server_id) {
+        $index->set('server', $new_server_id);
+        $index->save();
+        $logger->info('Updated server for index "@index" to "@new_server_id".', [
+          '@index' => $index->id(),
+          '@new_server_id' => $new_server_id,
+        ]);
+      }
+    }
+
+    // Check if the OLD 'content_index' config exists and the new 'primary' config does not.
+    if ($primary_index_config->isNew() && !$content_index_config->isNew()) {
+      $index_data = $content_index_config->getRawData();
+      $index_data['id'] = $new_index_id;
+      $index_data['name'] = 'Primary';
+      $primary_index_config->setData($index_data)->save();
+
+      // Delete the old 'content_index' configuration.
+      $content_index_config->delete();
+      $logger->info("Replaced index '{$old_index_id}' with '{$new_index_id}' and deleted old configuration.");
+    }
+
+    // Delete the old search server if it exists.
+    if ($pantheon_solr8_config) {
+      $pantheon_solr8_config->delete();
+      $logger->info("Deleted old search server '$old_server_id'.");
+    }
+
+  } catch (\Exception $e) {
+    $logger->error('Error occurred during search server migration: @message. Please re-run database updates.', [
+      '@message' => $e->getMessage(),
+    ]);
+    throw $e;
+  }
+}


### PR DESCRIPTION
_**This is a PR created for discussing about the issues if we update search index id and the fixes need to add to tackle the issue.**_

**Issue**
The bug [BUGS-9875] is related to the changes we have done in 8.3.x version  of Search API pantheon module https://getpantheon.atlassian.net/browse/SITE-1240
[Drupal.org Issue](https://www.drupal.org/project/search_api_pantheon/issues/3505065)
In 8.3.0, the server id  of Pantheon Search was changed from 'pantheon_solr8' to 'pantheon_search', and the  'Basic content index(content_index)'  in config/optional folder was replaced with a new index ' Primary (primary) 'in config/install folder. This issue primarily affects existing sites that upgrade from 8.2.x to 8.3.x — it doesn’t impact new installs.

**Fix added**

 When a user upgrade from Search API pantheon 8.2.x to 8.3.x version,
- The update hook updates the search server Id of Pantheon Search   from 'pantheon_solr8' to 'pantheon_search'.
- All existing indexes currently configured with 'pantheon_solr8' as their search server will be migrated to 'pantheon_search'.
- If there is a 'Basic content index (content_index)', it will be replaced with 'Primary(primary)' Index
- And then the old search server with id 'pantheon_solr8' will be deleted.

**Issues after Index migration.**

From my testing, for earlier versions the old index 'Basic content index (content_index)'will not be installed while we install the module , since it is not  in config/install folder. And I manually created a custom index 'content_index' for testing the migration process.

Replacing the index id with 'primary' has a significant drawback: All the  references of 'content_index' id in  views, search pages, and facets will get broken.

**Search API Page after migration**

<img width="1330" alt="search-api-page-after-migration" src="https://github.com/user-attachments/assets/b5f6ae18-f197-4139-a529-3c394f68aa67" />

**Search View before updating index id**


<img width="766" alt="custom-search-view-before-migration" src="https://github.com/user-attachments/assets/88f755f4-95a0-4b95-9c25-200f9a9fec66" />

**Search View after updating index id**

<img width="1127" alt="Search-view-after-migration" src="https://github.com/user-attachments/assets/cb84da2b-5d57-4198-accb-064a66b12df9" />

**Error getting on search page after updating index id**
`Drupal\Core\Database\DatabaseExceptionWrapper: Exception in Custom Search[custom_search]: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'FROM "search_api_index_content_index" "search_api_index_content_index" LIMIT ...' at line 3: SELECT FROM "search_api_index_content_index" "search_api_index_content_index" LIMIT 11 OFFSET 0; Array ( ) in main() (line 19 of /code/web/index.php).`








[BUGS-9875]: https://getpantheon.atlassian.net/browse/BUGS-9875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ