### PR TITLE
[BUGS-9875]  #1 Add fix to upgrade from earlier versions to 8.3.x

### DIFF
--- a/.ci/config/search_api.index.solr_index.yml
+++ b/.ci/config/search_api.index.solr_index.yml
@@ -7,7 +7,7 @@ dependencies:
     - node
     - search_api
   config:
-    - search_api.server.pantheon_solr8
+    - search_api.server.pantheon_search
 third_party_settings:
   search_api_solr:
     finalize: false
@@ -83,4 +83,4 @@ options:
   index_directly: true
   track_changes_in_references: true
   cron_limit: 50
-server: pantheon_solr8
+server: pantheon_search

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,20 +1,49 @@
+Search API Pantheon 8.3.3
+--------------------------------------------------
+This release includes an important bug fix that simplifies the transition of search server and index configurations when upgrading from earlier versions to 8.3.x.
+
+### What's Changed
+
+Bug Fix #3505065: This fix significantly improves the upgrade experience from previous versions to 8.3.x.
+
+- In version 8.3.0, the Pantheon Search server ID was updated to pantheon_search,and  the basic content index example configuration previously found in the config/optional folder has been replaced with a primary index located in the config/install folder.
+- This update now provides a smoother migration of the internal search server ID from pantheon_solr8 to pantheon_search and ensures the creation of a new basic index named primary.
+
+
+### Upgrade Instructions
+
+If you're upgrading from version 8.2.x or earlier to 8.3.x, you must run database updates to complete the migration.
+- Run 'drush updb' in your terminal or visit /update.php in your browser.
+
+Running the database update will:
+ - Update the search server ID from pantheon_solr8 to pantheon_search.
+ - Migrate all existing search indexes from the old pantheon_solr8 server to the   new pantheon_search server.
+ - Create the new 'primary' basic index.
+
+After database updates, indexed items will be staged for reindexing. Please re-index from the admin UI or by running the command:
+'drush search-api:reindex <INDEX_NAME>'.
+
+After that , please export the configuration changes  using  the command 'drush cex'.
+
+For new installations of version 8.3.x, no action is required. The new search server pantheon_search and index primary will be set up automatically.
+
 Search API Patheon 8.3.0
 --------------------------------------------------
 - Compatible with Pantheon Search (Solr 8)
-- Compatible with Drupal 10.x
+- Compatible with Drupal 11.x
 - Versions of Drupal less than 10 are not supported.
 - Versions of PHP less than 8.1 are not supported
 
-Search API Patheon 8.x-8.x-alpha1
+Search API Pantheon 8.x-8.x-alpha1
 --------------------------------------------------
 - Compatible with Pantheon Search (Solr 8)
 - Compatible with Drupal 9.x
 
-Search API Patheon 8.x-1.x-alpha2
+Search API Pantheon 8.x-1.x-alpha2
 --------------------------------------------------
 - Issue #2818001 by stevector: Refactor for SolrConnector Plugin
 - Issue #2761831 by stevector: Update .gitattributes file
 
-Search API Patheon 8.x-1.x-alpha1
+Search API Pantheon 8.x-1.x-alpha1
 --------------------------------------------------
 - Issue #2821769 by stevector: Initial release. Compatible with Search API Solr alpha6.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,19 +6,11 @@ This release includes an important bug fix that simplifies the transition of sea
 
 Bug Fix #3505065: This fix significantly improves the upgrade experience from previous versions to 8.3.x.
 
-- In version 8.3.0, the Pantheon Search server Id was updated to 'pantheon_search',and  the basic content index  configuration previously found in the config/optional folder has been replaced with  'primary index' located in the config/install folder.
+- In version 8.3.0, the Pantheon Search server id was updated to 'pantheon_search',and  the basic content index  configuration previously found in the config/optional folder has been replaced with  'primary index' located in the config/install folder.
 
-- This update now provides a smoother migration of the  search server Id from 'pantheon_solr8' to 'pantheon_search' and creates a new 'primary' index if you are using  'content_index' provided by earlier versions of the module.
+- This release now provides a smoother migration of the  search server Id from 'pantheon_solr8' to 'pantheon_search' and  updates the search server for all the indexes using 'pantheon_solr8' with 'pantheon_search'.
 
-Important Notes for Users:
-
-If you were actively using the old content_index (index created by earlier module versions),
-
-You can continue using your existing content_index (then disable the newly created primary index).
-
-or Migrate your associated entities from the old content_index to the new primary index  and disable the old 'content_index'.
-
- If you were already using custom search indexes in your site (not the module's default content_index), they remain unaffected by this update. These custom indexes will continue to function normally, now automatically pointing to the pantheon_search server.
+- If you are using the default 'content_index' provided by earlier versions of  the module you can continue using that.
 
 ### Upgrade Instructions
 
@@ -28,11 +20,11 @@ If you're upgrading from version 8.2.x or earlier to 8.3.x, you must run databas
 Running the database update will:
  - Update the search server ID from pantheon_solr8 to pantheon_search.
  - Migrate all existing search indexes from the old pantheon_solr8 server to the   new pantheon_search server.
- - Create the new 'primary' basic index, if you are using 'content_index' provided by the earlier vesrions of the module.
 
  ### Post-Update Steps:
 
-Re-index your data: After the database updates, indexed items will be staged for reindexing. Please re-index from the admin UI or by running the command:
+Re-index your data: After the database updates, since the server gets updated, indexed items will be staged for reindexing. Please re-index from the admin UI or by running the command:
+
 'drush search-api:reindex <INDEX_NAME>'
 
 Export configuration: After re-indexing is complete and you've verified your search setup, please export the configuration changes using the command:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,9 +6,19 @@ This release includes an important bug fix that simplifies the transition of sea
 
 Bug Fix #3505065: This fix significantly improves the upgrade experience from previous versions to 8.3.x.
 
-- In version 8.3.0, the Pantheon Search server ID was updated to pantheon_search,and  the basic content index example configuration previously found in the config/optional folder has been replaced with a primary index located in the config/install folder.
-- This update now provides a smoother migration of the internal search server ID from pantheon_solr8 to pantheon_search and ensures the creation of a new basic index named primary.
+- In version 8.3.0, the Pantheon Search server Id was updated to 'pantheon_search',and  the basic content index  configuration previously found in the config/optional folder has been replaced with  'primary index' located in the config/install folder.
 
+- This update now provides a smoother migration of the  search server Id from 'pantheon_solr8' to 'pantheon_search' and creates a new 'primary' index if you are using  'content_index' provided by earlier versions of the module.
+
+Important Notes for Users:
+
+If you were actively using the old content_index (index created by earlier module versions),
+
+You can continue using your existing content_index (then disable the newly created primary index).
+
+or Migrate your associated entities from the old content_index to the new primary index  and disable the old 'content_index'.
+
+ If you were already using custom search indexes in your site (not the module's default content_index), they remain unaffected by this update. These custom indexes will continue to function normally, now automatically pointing to the pantheon_search server.
 
 ### Upgrade Instructions
 
@@ -18,14 +28,16 @@ If you're upgrading from version 8.2.x or earlier to 8.3.x, you must run databas
 Running the database update will:
  - Update the search server ID from pantheon_solr8 to pantheon_search.
  - Migrate all existing search indexes from the old pantheon_solr8 server to the   new pantheon_search server.
- - Create the new 'primary' basic index.
+ - Create the new 'primary' basic index, if you are using 'content_index' provided by the earlier vesrions of the module.
 
-After database updates, indexed items will be staged for reindexing. Please re-index from the admin UI or by running the command:
-'drush search-api:reindex <INDEX_NAME>'.
+ ### Post-Update Steps:
 
-After that , please export the configuration changes  using  the command 'drush cex'.
+Re-index your data: After the database updates, indexed items will be staged for reindexing. Please re-index from the admin UI or by running the command:
+'drush search-api:reindex <INDEX_NAME>'
+(Replace <INDEX_NAME> with the specific index ID)
 
-For new installations of version 8.3.x, no action is required. The new search server pantheon_search and index primary will be set up automatically.
+Export configuration: After re-indexing is complete and you've verified your search setup, please export the configuration changes using the command:
+'drush cex'
 
 Search API Patheon 8.3.0
 --------------------------------------------------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,7 +34,6 @@ Running the database update will:
 
 Re-index your data: After the database updates, indexed items will be staged for reindexing. Please re-index from the admin UI or by running the command:
 'drush search-api:reindex <INDEX_NAME>'
-(Replace <INDEX_NAME> with the specific index ID)
 
 Export configuration: After re-indexing is complete and you've verified your search setup, please export the configuration changes using the command:
 'drush cex'

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,38 +1,31 @@
 Search API Pantheon 8.3.3
 --------------------------------------------------
-This release includes an important bug fix that simplifies the transition of search server and index configurations when upgrading from earlier versions to 8.3.x.
+This release includes an important bug fix that simplifies the transition of search configurations when upgrading from earlier versions to 8.3.x.
 
 ### What's Changed
 
 Bug Fix #3505065: This fix significantly improves the upgrade experience from previous versions to 8.3.x.
-
-- In version 8.3.0, the Pantheon Search server id was updated to 'pantheon_search',and  the basic content index  configuration previously found in the config/optional folder has been replaced with  new 'primary index' in  config/install folder.
-
-- This release now provides a smoother migration of the  search server Id from 'pantheon_solr8' to 'pantheon_search' and  updates the search server for all the indexes using 'pantheon_solr8' with 'pantheon_search'.
-
-- If you are using the default 'content_index' provided by earlier versions of the module you can continue using that, .
+- In version 8.3.0, the Pantheon Search server id was updated to 'pantheon_search',and the basic content index  configuration previously found in the config/optional folder has been replaced with  new 'primary index' in  config/install folder.
+- This release now provides a smoother migration of the  search server id from 'pantheon_solr8' to 'pantheon_search' and  all indexes previously linked to 'pantheon_solr8' will be updated to use the new 'pantheon_search' server.
+- If you're using the default content_index from earlier versions of the module, no changes are required. It will continue to work as expected.
 
 ### Upgrade Instructions
 
 If you're upgrading from version 8.2.x or earlier to 8.3.x, you must run database updates to complete the migration.
-- Run 'drush updb' in your terminal or visit /update.php in your browser.
-
+Run 'drush updb' in your terminal or visit /update.php in your browser.
 Running the database update will:
- - Update the search server ID from pantheon_solr8 to pantheon_search.
- - Migrate all existing search indexes from the old pantheon_solr8 server to the   new pantheon_search server.
+- Update the search server id from 'pantheon_solr8' to 'pantheon_search'.
+- Migrate all existing search indexes from the old 'pantheon_solr8' server to the new 'pantheon_search' server.
 
- ### Post-Update Steps:
+### Post-Update Steps:
 
-Re-index your data: After running the database updates, your search server will be updated, which causes previously indexed items to be flagged for reindexing.
-
+- After running the database updates, your search server will be updated, which causes previously indexed items to be flagged for reindexing.
 Please re-index from the admin UI or by running the command:
-
 'drush search-api:reindex <INDEX_NAME>'
-
-Export configuration: After re-indexing is complete and you've verified your search setup, please export the configuration changes using the command:
+- After re-indexing is complete and you've verified your search setup, please export the configuration changes using the command:
 'drush cex'
 
-Search API Patheon 8.3.0
+Search API Pantheon 8.3.0
 --------------------------------------------------
 - Compatible with Pantheon Search (Solr 8)
 - Compatible with Drupal 11.x

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,11 +6,11 @@ This release includes an important bug fix that simplifies the transition of sea
 
 Bug Fix #3505065: This fix significantly improves the upgrade experience from previous versions to 8.3.x.
 
-- In version 8.3.0, the Pantheon Search server id was updated to 'pantheon_search',and  the basic content index  configuration previously found in the config/optional folder has been replaced with  'primary index' located in the config/install folder.
+- In version 8.3.0, the Pantheon Search server id was updated to 'pantheon_search',and  the basic content index  configuration previously found in the config/optional folder has been replaced with  new 'primary index' in  config/install folder.
 
 - This release now provides a smoother migration of the  search server Id from 'pantheon_solr8' to 'pantheon_search' and  updates the search server for all the indexes using 'pantheon_solr8' with 'pantheon_search'.
 
-- If you are using the default 'content_index' provided by earlier versions of  the module you can continue using that.
+- If you are using the default 'content_index' provided by earlier versions of the module you can continue using that, .
 
 ### Upgrade Instructions
 
@@ -23,7 +23,9 @@ Running the database update will:
 
  ### Post-Update Steps:
 
-Re-index your data: After the database updates, since the server gets updated, indexed items will be staged for reindexing. Please re-index from the admin UI or by running the command:
+Re-index your data: After running the database updates, your search server will be updated, which causes previously indexed items to be flagged for reindexing.
+
+Please re-index from the admin UI or by running the command:
 
 'drush search-api:reindex <INDEX_NAME>'
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Search API Pantheon: Solr 8 & Drupal 9/10 Integration
+# Search API Pantheon: Solr 8 & Drupal 9.4+ Integration
 
 [![Search API Pantheon](https://github.com/pantheon-systems/search_api_pantheon/actions/workflows/ci.yml/badge.svg?branch=8.x)](https://github.com/pantheon-systems/search_api_pantheon/actions/workflows/ci.yml)
-[![Limited Availability](https://img.shields.io/badge/Pantheon-Limited_Availability-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#limited-availability)
+[![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#actively-maintained-support)
 
 ## Important Notice - Schema Reversion Prevention
 
@@ -18,7 +18,7 @@ Users experiencing these issues should upgrade immediately to version 8.1.x-dev.
 
 This module is for you if you meet the following requirements:
 
-- Using Drupal 9.4/10
+- Using Drupal 9.4+
 - Hosting the Drupal site on Pantheon's platform
 - Your site uses `composer` to install modules and upgrade Drupal core using one of the following integrations:
 
@@ -35,7 +35,7 @@ Search API Solr provides the ability to connect to any Solr server by providing 
 
 ## What it provides
 
-This module provides [Drupal 9 and 10](https://drupal.org) integration with the [Apache Solr project](https://solr.apache.org/guide/8_8/). Pantheon's current version as of the update of this document is 8.11.4.
+This module provides [Drupal 9.4+](https://drupal.org) integration with the [Apache Solr project](https://solr.apache.org/guide/8_8/). Pantheon's current version as of the update of this document is 8.11.4.
 
 ## Composer
 
@@ -80,13 +80,9 @@ To configure the connection with Pantheon, perform the following steps on your D
 
 #### Enable Solr 8 in your pantheon.yml file
 
-  - Add the bolded portion to your `pantheon.yml` file:
+  - Add or update the following in your `pantheon.yml` file:
 
     ```yaml
-    php_version: 8.1
-    database:
-      version: 10.4
-    drush_version: 10
     search:
       version: 8
     ```
@@ -250,4 +246,3 @@ Once you have enabled the Search API Pantheon module, when you reload the schema
 ## Feedback and Collaboration
 
 Bug reports, feature requests, and feedback should be posted in [the drupal.org issue queue.](https://www.drupal.org/project/issues/search_api_pantheon?categories=All) For code changes, please submit pull requests against the [GitHub repository](https://github.com/pantheon-systems/search_api_pantheon).
-

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Composer is the way you should be managing your drupal module requirements. This
 To install this module via composer, run the following command in your Drupal root:
 
 ```bash
-composer require 'drupal/search_api_pantheon:^8.1'
+composer require 'drupal/search_api_pantheon:^8.3'
 ```
 
 ### Development Version
@@ -63,7 +63,7 @@ composer require 'drupal/search_api_pantheon:^8.1'
 Note that the above will install the latest stable release of this module. To install the latest development version, use:
 
 ```bash
-composer require 'drupal/search_api_pantheon:8.1.x-dev@dev'
+composer require 'drupal/search_api_pantheon:8.3.x-dev@dev'
 ```
 
 ## Setup

--- a/config/install/search_api.index.primary.yml
+++ b/config/install/search_api.index.primary.yml
@@ -51,9 +51,9 @@ third_party_settings:
       specific_languages:
         en: '0'
       use_universal_collation: false
-id: primary
+id: Primary
 name: primary
-description: ''
+description: 'Default Search Index for Pantheon Search'
 read_only: false
 field_settings: {  }
 datasource_settings:

--- a/config/install/search_api.index.primary.yml
+++ b/config/install/search_api.index.primary.yml
@@ -51,8 +51,8 @@ third_party_settings:
       specific_languages:
         en: '0'
       use_universal_collation: false
-id: Primary
-name: primary
+id: primary
+name: Primary
 description: 'Default Search Index for Pantheon Search'
 read_only: false
 field_settings: {  }

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -45,7 +45,6 @@ function search_api_pantheon_update_8300() {
   $logger                 = \Drupal::logger('search_api_pantheon');
 
   // Skip migration if :
-  // - it's not an update from 8.2.x or earlier versions.
   // - 'pantheon_solr8' search server doesn't exists,
   // - or the 'pantheon_search' server already exists.
   if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew())) {

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -29,7 +29,6 @@ function search_api_pantheon_requirements($phase) {
   return $requirements;
 }
 
-
 /**
  * Implements hook_update_N().
  *
@@ -78,7 +77,7 @@ function search_api_pantheon_update_8300() {
       }
     }
     // Create a 'primary' index by duplicating 'content_index'.
-   //  This is executed only if 'content_index' (from prior versions) exists.
+    //  This is executed only if 'content_index' (from prior versions) exists.
     $old_index = Index::load($old_index_id);
     if ($old_index && $primary_index_config->isNew()) {
       $new_index = $old_index->createDuplicate();

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -34,8 +34,7 @@ function search_api_pantheon_requirements($phase) {
  *
  * This update hook assists in the transition when upgrading the
  * module from earlier versions to 8.3.x.
- * It updates the search server from 'pantheon_solr8' to 'pantheon_search',
- * and creates a new 'primary' index if the 'content_index' (provided by earlier versions) exists.
+ * It updates the search server from 'pantheon_solr8' to 'pantheon_search'.
  */
 function search_api_pantheon_update_8300() {
   $old_server_id          = 'pantheon_solr8';
@@ -50,9 +49,9 @@ function search_api_pantheon_update_8300() {
 
   // Skip migration if :
   // - it's not an update from 8.2.x or earlier versions.
-  // - 'pantheon_solr8' search server doesn't exist,
-  // - or both the 'pantheon_search' server and 'primary' index already exist.
-  if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew() && !$primary_index_config->isNew())) {
+  // - 'pantheon_solr8' search server doesn't exists,
+  // - or the 'pantheon_search' server already exists.
+  if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew()) {
     return;
   }
 
@@ -76,25 +75,8 @@ function search_api_pantheon_update_8300() {
         ]);
       }
     }
-    // Create a 'primary' index by duplicating 'content_index'.
-    //  This is executed only if 'content_index' (from prior versions) exists.
-    $old_index = Index::load($old_index_id);
-    if ($old_index && $primary_index_config->isNew()) {
-      $new_index = $old_index->createDuplicate();
-      $new_index->set('id', $new_index_id);
-      $new_index->set('name', 'Primary');
-      $new_index->enforceIsNew();
-      $new_index->save();
-      $logger->info("Created new index 'Primary'. ");
-    }
 
-    // Commenting the code for deletion of old index,
-    // since the old index deletion should be done manually, if needed).
-    //
-    // $old_index->delete();
-    // $logger->notice('Old index @old deleted.', ['@old' => $old_index_id]);
-
-    // Delete the old search server, if it exists.
+     // Delete the old search server, if it exists.
     $old_server = Server::load($old_server_id);
     if ($old_server) {
       $old_server->delete();

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -51,7 +51,7 @@ function search_api_pantheon_update_8300() {
   // - it's not an update from 8.2.x or earlier versions.
   // - 'pantheon_solr8' search server doesn't exists,
   // - or the 'pantheon_search' server already exists.
-  if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew()) {
+  if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew())) {
     return;
   }
 

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -6,7 +6,6 @@
  */
 
 use Drupal\search_api_pantheon\Plugin\SolrConnector\PantheonSolrConnector;
-use Drupal\search_api\Entity\Index;
 use Drupal\search_api\Entity\Server;
 
 /**
@@ -76,7 +75,7 @@ function search_api_pantheon_update_8300() {
       }
     }
 
-     // Delete the old search server, if it exists.
+    // Delete the old search server, if it exists.
     $old_server = Server::load($old_server_id);
     if ($old_server) {
       $old_server->delete();

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -39,11 +39,9 @@ function search_api_pantheon_update_8300() {
   $old_server_id          = 'pantheon_solr8';
   $new_server_id          = 'pantheon_search';
   $old_index_id           = 'content_index';
-  $new_index_id           = 'primary';
   $config_factory         = \Drupal::configFactory();
   $pantheon_solr8_config  = $config_factory->getEditable("search_api.server.pantheon_solr8");
   $pantheon_search_config = $config_factory->getEditable("search_api.server.pantheon_search");
-  $primary_index_config   = $config_factory->getEditable("search_api.index.primary");
   $logger                 = \Drupal::logger('search_api_pantheon');
 
   // Skip migration if :

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -6,6 +6,8 @@
  */
 
 use Drupal\search_api_pantheon\Plugin\SolrConnector\PantheonSolrConnector;
+use Drupal\search_api\Entity\Index;
+use Drupal\search_api\Entity\Server;
 
 /**
  * Implements hook_requirements().
@@ -25,4 +27,79 @@ function search_api_pantheon_requirements($phase) {
   }
 
   return $requirements;
+}
+
+/**
+ * Updates search server and index configuration during module upgrade.
+ *
+ * This update hook assists in the transition when upgrading the
+ * Search API Pantheon module from earlier versions to 8.3.x.
+ * It updates the search server from 'pantheon_solr8' to 'pantheon_search',
+ * and  creates new index 'primary'.
+ */
+function search_api_pantheon_update_8300() {
+  $old_server_id          = 'pantheon_solr8';
+  $new_server_id          = 'pantheon_search';
+  $old_index_id           = 'content_index';
+  $new_index_id           = 'primary';
+  $config_factory         = \Drupal::configFactory();
+  $pantheon_solr8_config  = $config_factory->getEditable("search_api.server.pantheon_solr8");
+  $pantheon_search_config = $config_factory->getEditable("search_api.server.pantheon_search");
+  $primary_index_config   = $config_factory->getEditable("search_api.index.primary");
+  $logger                 = \Drupal::logger('search_api_pantheon');
+
+  // Skip migration if 'pantheon_solr8' search server doesn't exist,
+  // or if both the 'pantheon_search' server and 'primary' index already exist.
+  if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew() && !$primary_index_config->isNew())) {
+    return;
+  }
+
+  try {
+    // Create the 'pantheon_search' server  if it doesn't exist.
+    if ($pantheon_search_config->isNew()) {
+      $data = $pantheon_solr8_config->getRawData();
+      $data['id'] = $new_server_id;
+      $pantheon_search_config->setData($data)->save();
+      $logger->info("Search server ID changed from '$old_server_id' to '$new_server_id'.");
+    }
+    // Update all search indexes with 'pantheon_solr8' as search server to 'pantheon_search'
+    $indexes = \Drupal::entityTypeManager()->getStorage('search_api_index')->loadMultiple();
+    foreach ($indexes as $index) {
+      if ($index->get('server') === $old_server_id) {
+        $index->set('server', $new_server_id);
+        $index->save();
+        $logger->info('Updated server for index "@index" to "@new_server_id".', [
+          '@index' => $index->id(),
+          '@new_server_id' => $new_server_id,
+        ]);
+      }
+    }
+    // Create a duplicate index from  'content_index' index, if it  exists.
+    $old_index = Index::load($old_index_id);
+    if ($old_index && $primary_index_config->isNew()) {
+      $new_index = $old_index->createDuplicate();
+      $new_index->set('id', $new_index_id);
+      $new_index->set('name', 'Primary');
+      $new_index->enforceIsNew();
+      $new_index->save();
+      $logger->info("Created new index 'Primary'. ");
+    }
+    // Delete the old index.
+    // $old_index->delete();
+    // $logger->notice('Old index @old deleted.', ['@old' => $old_index_id]);
+
+    //  Delete the old search server if it exists.
+    $old_server = Server::load($old_server_id);
+    if ($old_server) {
+      $old_server->delete();
+      $logger->info("Deleted old search server '$old_server_id'.");
+    }
+
+  }
+  catch (\Exception $e) {
+    $logger->error('Error occurred during Search API Pantheon migration: @message. Please re-run database updates.', [
+      '@message' => $e->getMessage(),
+    ]);
+    throw $e;
+  }
 }

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -29,13 +29,14 @@ function search_api_pantheon_requirements($phase) {
   return $requirements;
 }
 
+
 /**
- * Updates search server and index configuration during module upgrade.
+ * Implements hook_update_N().
  *
  * This update hook assists in the transition when upgrading the
- * Search API Pantheon module from earlier versions to 8.3.x.
+ * module from earlier versions to 8.3.x.
  * It updates the search server from 'pantheon_solr8' to 'pantheon_search',
- * and  creates new index 'primary'.
+ * and creates a new 'primary' index if the 'content_index' (provided by earlier versions) exists.
  */
 function search_api_pantheon_update_8300() {
   $old_server_id          = 'pantheon_solr8';
@@ -48,8 +49,10 @@ function search_api_pantheon_update_8300() {
   $primary_index_config   = $config_factory->getEditable("search_api.index.primary");
   $logger                 = \Drupal::logger('search_api_pantheon');
 
-  // Skip migration if 'pantheon_solr8' search server doesn't exist,
-  // or if both the 'pantheon_search' server and 'primary' index already exist.
+  // Skip migration if :
+  // - it's not an update from 8.2.x or earlier versions.
+  // - 'pantheon_solr8' search server doesn't exist,
+  // - or both the 'pantheon_search' server and 'primary' index already exist.
   if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew() && !$primary_index_config->isNew())) {
     return;
   }
@@ -74,7 +77,8 @@ function search_api_pantheon_update_8300() {
         ]);
       }
     }
-    // Create a duplicate index from  'content_index' index, if 'content_index' index  exists.
+    // Create a 'primary' index by duplicating 'content_index'.
+   //  This is executed only if 'content_index' (from prior versions) exists.
     $old_index = Index::load($old_index_id);
     if ($old_index && $primary_index_config->isNew()) {
       $new_index = $old_index->createDuplicate();
@@ -84,11 +88,14 @@ function search_api_pantheon_update_8300() {
       $new_index->save();
       $logger->info("Created new index 'Primary'. ");
     }
-    // Delete the old index.
+
+    // Commenting the code for deletion of old index,
+    // since the old index deletion should be done manually, if needed).
+    //
     // $old_index->delete();
     // $logger->notice('Old index @old deleted.', ['@old' => $old_index_id]);
 
-    //  Delete the old search server, if it exists.
+    // Delete the old search server, if it exists.
     $old_server = Server::load($old_server_id);
     if ($old_server) {
       $old_server->delete();

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -55,7 +55,7 @@ function search_api_pantheon_update_8300() {
   }
 
   try {
-    // Create the 'pantheon_search' server  if it doesn't exist.
+    // Update the search server id 'pantheon_solr8' to  'pantheon_search' server
     if ($pantheon_search_config->isNew()) {
       $data = $pantheon_solr8_config->getRawData();
       $data['id'] = $new_server_id;
@@ -74,7 +74,7 @@ function search_api_pantheon_update_8300() {
         ]);
       }
     }
-    // Create a duplicate index from  'content_index' index, if it  exists.
+    // Create a duplicate index from  'content_index' index, if 'content_index' index  exists.
     $old_index = Index::load($old_index_id);
     if ($old_index && $primary_index_config->isNew()) {
       $new_index = $old_index->createDuplicate();
@@ -88,7 +88,7 @@ function search_api_pantheon_update_8300() {
     // $old_index->delete();
     // $logger->notice('Old index @old deleted.', ['@old' => $old_index_id]);
 
-    //  Delete the old search server if it exists.
+    //  Delete the old search server, if it exists.
     $old_server = Server::load($old_server_id);
     if ($old_server) {
       $old_server->delete();

--- a/src/Commands/Schema.php
+++ b/src/Commands/Schema.php
@@ -48,7 +48,7 @@ class Schema extends DrushCommands {
    *
    * @usage search-api-pantheon:postSchema [server_id] [path]
    *   Post the latest schema to the given Server.
-   *   Default server ID = pantheon_solr8.
+   *   Default server ID = pantheon_search.
    *   Default path = empty (build files using search_api_solr mechanism).
    *
    * @command search-api-pantheon:postSchema

--- a/src/Services/Endpoint.php
+++ b/src/Services/Endpoint.php
@@ -23,7 +23,7 @@ use Solarium\Core\Client\Endpoint as SolariumEndpoint;
  */
 class Endpoint extends SolariumEndpoint {
 
-  const DEFAULT_NAME = 'pantheon_solr8';
+  const DEFAULT_NAME = 'pantheon_search';
 
   /**
    * Default name for Endpoint.

--- a/src/Services/SchemaPoster.php
+++ b/src/Services/SchemaPoster.php
@@ -250,7 +250,7 @@ class SchemaPoster implements LoggerAwareInterface {
    * Get the schema and config files for posting on the solr server.
    *
    * @param string $server_id
-   *   The Search API server id. Typically, `pantheon_solr8`.
+   *   The Search API server id. Typically, `pantheon_search`.
    *
    * @return array
    *   Array of key-value pairs: 'filename' => 'file contents'.


### PR DESCRIPTION
**Issue**
The bug [BUGS-9875] is related to the changes we have done in 8.3.x version  of Search API pantheon module https://getpantheon.atlassian.net/browse/SITE-1240
[Drupal.org Issue](https://www.drupal.org/project/search_api_pantheon/issues/3505065)
In 8.3.0, the server id  of **Pantheon Search** was changed from **'pantheon_solr8'** to **'pantheon_search'**, and the  **Basic content index(content_index')**  in config/optional folder was replaced with a new index  **Primary (primary)** in config/install folder. 

**Fix added**

When a user upgrade from Search API pantheon 8.2.x to 8.3.x version,
- The update hook will update  the search server Id of Pantheon Search   from 'pantheon_solr8' to 'pantheon_search'.
- All existing indexes currently configured with 'pantheon_solr8' as their search server will be migrated to 'pantheon_search'.
- And then the old search server with id 'pantheon_solr8' will be deleted.

**_Reverted this changes_**
> 
> - Instead of updating the id of  the 'content_index' with 'primary' , a duplicate of 'content_index'  will be created and saved as 'Primary' index.
> 
> This is because , if 'content_index' has any associated view, search page , facets  or any other referenced entities, it will get broken. So by creating a duplicate of the 'content_index' , the new index will gets created, and if the customers want they can  move the associated entities for the old index to new primary index and remove the old content index manually later.
> 
> If the customers were not using the old index ('content_index') provided in the module,  they can still use the custom index they were using. 
> 
> NB: Whenever I tested the version 8.2.2, old content_index was never installed, even though I already had the dependencies( Search API, Search API Solr, Solr Backend) installed. So I tested the migration by manually creating an index with id 'content_index.


_**Attaching another PR where index id is replaced instead of creating the duplicate.**_

https://github.com/pantheon-systems/search_api_pantheon/pull/220

Created a site on prod and tested.

<img width="1365" height="557" alt="Screenshot 2025-07-10 at 5 58 28 PM" src="https://github.com/user-attachments/assets/cb050584-6611-4f27-934b-2669cb0ecc0f" />





[BUGS-9875]: https://getpantheon.atlassian.net/browse/BUGS-9875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ