### PR TITLE
[BUGS-9875] #2 Fix for Pantheon Solr8 search server

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,8 +9,8 @@ Bug Fix #3505065: This fix significantly improves the upgrade experience from pr
 - This release now provides a smoother migration of the  search server id from 'pantheon_solr8' to 'pantheon_search' and  all indexes previously linked to 'pantheon_solr8' will be updated to use the new 'pantheon_search' server.
 - If you're using the default content_index from earlier versions of the module, no changes are required. It will continue to work as expected.
 
-### Optional:
-If you prefer to keep using the old server id 'pantheon_solr8'  and skip the migration, add the following line to your settings.php file before running updates:
+### Optional: Skip Search Server Migration
+If you prefer to keep using the old server with  id 'pantheon_solr8'  and skip the migration, add the following line to your settings.php file before running database updates:
 
 $settings['default_search_server'] = 'pantheon_solr8';
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,13 @@ Bug Fix #3505065: This fix significantly improves the upgrade experience from pr
 - This release now provides a smoother migration of the  search server id from 'pantheon_solr8' to 'pantheon_search' and  all indexes previously linked to 'pantheon_solr8' will be updated to use the new 'pantheon_search' server.
 - If you're using the default content_index from earlier versions of the module, no changes are required. It will continue to work as expected.
 
+### Optional:
+If you prefer to keep using the old server id 'pantheon_solr8'  and skip the migration, add the following line to your settings.php file before running updates:
+
+$settings['default_search_server'] = 'pantheon_solr8';
+
+This will prevent the migration of 'pantheon_solr8' to 'pantheon_search'.
+
 ### Upgrade Instructions
 
 If you're upgrading from version 8.2.x or earlier to 8.3.x, you must run database updates to complete the migration.

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ If you experience schema reversion issues:
 
 The current default schema on Pantheon when a new Solr container is provisioned is the 4.2.1 version of the solr8 jump-start config set provided by the Search API Solr module. To upgrade the default Pantheon Search server to a version 4.3.0+ compatible config set, run the following command after you've upgraded the Search API Solr module to your desired version.
 
-`drush search-api-pantheon:postSchema pantheon_search/code/web/modules/contrib/search_api_solr/jump-start/solr8/config-set/`
+`drush search-api-pantheon:postSchema pantheon_search /code/web/modules/contrib/search_api_solr/jump-start/solr8/config-set/`
 
 Once you have enabled the Search API Pantheon module, when you reload the schema the Pantheon module will use the config-set for the version of the Search API Solr module installed in your codebase. See the [Search API Solr 4.3.0 release notes](https://www.drupal.org/project/search_api_solr/releases/4.3.0) for more information about upgrading to a 4.3.0+ compatible schema.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Starting with version 8.1.x, Search API Pantheon automatically reloads the Solr 
 
 Schema updates can be performed through:
 
-- Admin UI: Navigate to `/admin/config/search/search-api/server/pantheon_solr8/pantheon-admin/schema`
+- Admin UI: Navigate to `/admin/config/search/search-api/server/pantheon_search/pantheon-admin/schema`
 - Drush: Run `drush search-api-pantheon:postSchema`
 
 #### Manual Core Reload
@@ -237,7 +237,7 @@ If you experience schema reversion issues:
 
 The current default schema on Pantheon when a new Solr container is provisioned is the 4.2.1 version of the solr8 jump-start config set provided by the Search API Solr module. To upgrade the default Pantheon solr 8 server to a version 4.3.0+ compatible config set, run the following command after you've upgraded the Search API Solr module to your desired version.
 
-`drush search-api-pantheon:postSchema pantheon_solr8 /code/web/modules/contrib/search_api_solr/jump-start/solr8/config-set/`
+`drush search-api-pantheon:postSchema pantheon_search /code/web/modules/contrib/search_api_solr/jump-start/solr8/config-set/`
 
 Once you have enabled the Search API Pantheon module, when you reload the schema the Pantheon module will use the config-set for the version of the Search API Solr module installed in your codebase. See the [Search API Solr 4.3.0 release notes](https://www.drupal.org/project/search_api_solr/releases/4.3.0) for more information about upgrading to a 4.3.0+ compatible schema.
 

--- a/README.md
+++ b/README.md
@@ -227,17 +227,17 @@ If you experience schema reversion issues:
 - `drush search-api-pantheon:diagnose` (`sapd`) The DIAGNOSE command will check the various pieces of the Search API install
   and throw errors on the pieces that are not working. This command will develop further as the module nears general availability.
 
-- `drush search-api-pantheon:select` (`saps`) This command will run the given query against Solr server. It's recommended to use
+- `drush search-api-pantheon:select [solr-server]` (`saps`) This command will run the given query against Solr server. It's recommended to use
   `?debug=true` in any Solr page (having the right permissions) to get a good query to pass to this command to debug results.
 
-- `drush search-api-pantheon:force-cleanup` (`sapfc`) This command will delete all of the contents for the given
+- `drush search-api-pantheon:force-cleanup [solr-server]` (`sapfc`) This command will delete all of the contents for the given
   Solr server (no matter if hash or index_id have changed).
 
 - `drush search-api-pantheon:postSchema [solr-server] [path-to-schema]` (`sapps`) This command will upload schema files to the solr server. It can be used to reset a solr schema to the default Pantheon configuration, upgrade a schema, or to use a custom config set.
 
-The current default schema on Pantheon when a new Solr container is provisioned is the 4.2.1 version of the solr8 jump-start config set provided by the Search API Solr module. To upgrade the default Pantheon solr 8 server to a version 4.3.0+ compatible config set, run the following command after you've upgraded the Search API Solr module to your desired version.
+The current default schema on Pantheon when a new Solr container is provisioned is the 4.2.1 version of the solr8 jump-start config set provided by the Search API Solr module. To upgrade the default Pantheon Search server to a version 4.3.0+ compatible config set, run the following command after you've upgraded the Search API Solr module to your desired version.
 
-`drush search-api-pantheon:postSchema pantheon_search /code/web/modules/contrib/search_api_solr/jump-start/solr8/config-set/`
+`drush search-api-pantheon:postSchema pantheon_search/code/web/modules/contrib/search_api_solr/jump-start/solr8/config-set/`
 
 Once you have enabled the Search API Pantheon module, when you reload the schema the Pantheon module will use the config-set for the version of the Search API Solr module installed in your codebase. See the [Search API Solr 4.3.0 release notes](https://www.drupal.org/project/search_api_solr/releases/4.3.0) for more information about upgrading to a 4.3.0+ compatible schema.
 

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -7,6 +7,7 @@
 
 use Drupal\search_api_pantheon\Plugin\SolrConnector\PantheonSolrConnector;
 use Drupal\search_api\Entity\Server;
+use Drupal\Core\Site\Settings;
 
 /**
  * Implements hook_requirements().
@@ -43,11 +44,13 @@ function search_api_pantheon_update_8300() {
   $pantheon_solr8_config  = $config_factory->getEditable("search_api.server.pantheon_solr8");
   $pantheon_search_config = $config_factory->getEditable("search_api.server.pantheon_search");
   $logger                 = \Drupal::logger('search_api_pantheon');
+  $default_search_server  = Settings::get('default_search_server', NULL);
 
   // Skip migration if :
   // - 'pantheon_solr8' search server doesn't exists,
   // - or the 'pantheon_search' server already exists.
-  if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew())) {
+  // - Default search server is set as 'pantheon_solr8' in settings.php
+   if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew()) || $default_search_server === 'pantheon_solr8') {
     return;
   }
 

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -50,7 +50,7 @@ function search_api_pantheon_update_8300() {
   // - 'pantheon_solr8' search server doesn't exists,
   // - or the 'pantheon_search' server already exists.
   // - Default search server is set as 'pantheon_solr8' in settings.php
-   if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew()) || $default_search_server === 'pantheon_solr8') {
+  if ($pantheon_solr8_config->isNew() || (!$pantheon_search_config->isNew()) || $default_search_server === 'pantheon_solr8') {
     return;
   }
 

--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -122,7 +122,7 @@ class Query extends DrushCommands {
    * @throws \Drupal\search_api_solr\SearchApiSolrException
    * @throws \Exception
    */
-  public function forceServerClean($server_id = 'pantheon_solr8') {
+  public function forceServerClean($server_id = 'pantheon_search') {
 
     $server = Server::load($server_id);
     $backend = $server->getBackend();

--- a/src/Plugin/SolrConnector/PantheonSolrConnector.php
+++ b/src/Plugin/SolrConnector/PantheonSolrConnector.php
@@ -257,7 +257,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
    *   The endpoint name.
    */
   public static function getDefaultEndpoint() {
-     return PantheonEndpoint::getDefaultSearchServer();
+    return PantheonEndpoint::getDefaultSearchServer();
   }
 
   /**

--- a/src/Plugin/SolrConnector/PantheonSolrConnector.php
+++ b/src/Plugin/SolrConnector/PantheonSolrConnector.php
@@ -257,7 +257,7 @@ class PantheonSolrConnector extends SolrConnectorPluginBase implements
    *   The endpoint name.
    */
   public static function getDefaultEndpoint() {
-    return PantheonEndpoint::DEFAULT_NAME;
+     return PantheonEndpoint::getDefaultSearchServer();
   }
 
   /**

--- a/src/Services/Endpoint.php
+++ b/src/Services/Endpoint.php
@@ -3,6 +3,7 @@
 namespace Drupal\search_api_pantheon\Services;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Site\Settings;
 use Drupal\search_api_pantheon\Plugin\SolrConnector\PantheonSolrConnector;
 use Drupal\search_api_solr\SolrConnectorInterface;
 use Solarium\Core\Client\Endpoint as SolariumEndpoint;
@@ -52,8 +53,9 @@ class Endpoint extends SolariumEndpoint {
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   public function __construct(array $options, EntityTypeManagerInterface $entityTypeManager) {
+    $server_id = $this->getDefaultSearchServer();
     /** @var \Drupal\search_api\ServerInterface $server */
-    $server = $entityTypeManager->getStorage('search_api_server')->load(self::DEFAULT_NAME);
+    $server = $entityTypeManager->getStorage('search_api_server')->load($server_id);
     $timeout_config = [];
     if ($server) {
       $connector_config = $server->getBackendConfig()['connector_config'];
@@ -254,7 +256,17 @@ class Endpoint extends SolariumEndpoint {
    *   Always use the default name.
    */
   public function getKey(): ?string {
-    return self::DEFAULT_NAME;
+    return $this->getDefaultSearchServer();
+  }
+
+  /**
+   * Get the name of default search server.
+   *
+   * @return string|null
+   *   The default search server name.
+   */
+  public function getDefaultSearchServer(): ?string {
+   return Settings::get('default_search_server', self::DEFAULT_NAME);
   }
 
 }

--- a/src/Services/Endpoint.php
+++ b/src/Services/Endpoint.php
@@ -266,7 +266,7 @@ class Endpoint extends SolariumEndpoint {
    *   The default search server name.
    */
   public function getDefaultSearchServer(): ?string {
-   return Settings::get('default_search_server', self::DEFAULT_NAME);
+    return Settings::get('default_search_server', self::DEFAULT_NAME);
   }
 
 }


### PR DESCRIPTION
Fix Added

- Added support for skipping the automatic migration from pantheon_solr8 to pantheon_search during database updates if the following line is set in settings.php:
`$settings['default_search_server'] = 'pantheon_solr8';`

- Updated the Solr endpoint logic to use the value defined in settings.php as the default search server. If no value is set, it will set default  name to 'pantheon_search'.

- Updated README command examples to allow passing a custom Solr server ID.
(If no Solr server ID is specified, pantheon_search will be used by default.)

@greg-1-anderson There are some codacy warnings, I will correct it, if the logic of the rest of the code looks okay to you.