### PR TITLE
[SITE-5117] Fix error for post schema command if server id is not passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Starting with version 8.1.x, Search API Pantheon automatically reloads the Solr 
 Schema updates can be performed through:
 
 - Admin UI: Navigate to `/admin/config/search/search-api/server/pantheon_search/pantheon-admin/schema`
-- Drush: Run `drush search-api-pantheon:postSchema`
+- Drush: Run `drush search-api-pantheon:postSchema [solr-server]`
 
 #### Manual Core Reload
 

--- a/src/Services/Endpoint.php
+++ b/src/Services/Endpoint.php
@@ -265,7 +265,7 @@ class Endpoint extends SolariumEndpoint {
    * @return string|null
    *   The default search server name.
    */
-  public function getDefaultSearchServer(): ?string {
+  public static function getDefaultSearchServer(): ?string {
     return Settings::get('default_search_server', self::DEFAULT_NAME);
   }
 


### PR DESCRIPTION
**Drush command**

`drush search-api-pantheon:postSchema [solr-server] [path-to-schema] (sapps) `

This command will upload schema files to the solr server and can be  used to reset a solr schema to the default Pantheon configuration, upgrade a schema, or to use a custom config set.

**Issue**

If we  run the command without specifying a Solr server ID 
`drush search-api-pantheon:postSchema `

The command will throw error in all 8.3.x versions.

- In version **8.3.0-8.3.2** the default search server installed renamed to  pantheon_search.
but  the hardcoded value in the code was still pantheon_solr8, which caused a mismatch and led to this error.

<img width="1706" height="314" alt="Screenshot 2025-07-24 at 12 11 28 PM" src="https://github.com/user-attachments/assets/f20d0554-656f-400f-a99a-9045ceab2ba7" />

-  In version **8.3.3,** the default search server was updated to pantheon_search to fix the mismatch.
 But the non-static method added is called  statically if server id is not passed as an argument in postschema command , 
https://github.com/pantheon-systems/search_api_pantheon/blob/8.x/src/Commands/Schema.php#L65
https://github.com/pantheon-systems/search_api_pantheon/blob/c4108731ff28b87a32aed0520acaadf4654d3777/src/Plugin/SolrConnector/PantheonSolrConnector.php#L260

it will result in the following error:
`Error: Non-static method Drupal\search_api_pantheon\Services\Endpoint::getDefaultSearchServer() cannot be called statically in Drupal\search_api_pantheon\Plugin\SolrConnector\PantheonSolrConnector::getDefaultEndpoint() (line 260 of /code/web/modules/contrib/search_api_pantheon/src/Plugin/SolrConnector/PantheonSolrConnector.php).
 [warning] Drush command terminated `abnormally.``

<img width="1728" height="92" alt="Screenshot 2025-07-24 at 12 03 29 PM" src="https://github.com/user-attachments/assets/f6669c04-13aa-4858-bcfd-cbac52d077fa" />


**After adding the fix**
<img width="935" height="51" alt="Screenshot 2025-07-24 at 12 02 34 PM" src="https://github.com/user-attachments/assets/32e3e7e9-8db7-4db7-afd4-c362a59ff67f" />

`