### PR TITLE
[Site-5118] Drush Command Fixes and Improvements

### DIFF
--- a/src/Commands/Query.php
+++ b/src/Commands/Query.php
@@ -122,8 +122,10 @@ class Query extends DrushCommands {
    * @throws \Drupal\search_api_solr\SearchApiSolrException
    * @throws \Exception
    */
-  public function forceServerClean($server_id = 'pantheon_search') {
-
+  public function forceServerClean($server_id = NULL) {
+    if (!$server_id) {
+      $server_id = $this->endpoint->getDefaultSearchServer();
+    }
     $server = Server::load($server_id);
     $backend = $server->getBackend();
     $connector = $backend->getSolrConnector();

--- a/src/Commands/TestIndexAndQuery.php
+++ b/src/Commands/TestIndexAndQuery.php
@@ -171,7 +171,6 @@ class TestIndexAndQuery extends DrushCommands {
     );
   }
 
-
   /**
    * Pings the Solr host.
    *

--- a/src/Commands/TestIndexAndQuery.php
+++ b/src/Commands/TestIndexAndQuery.php
@@ -99,6 +99,15 @@ class TestIndexAndQuery extends DrushCommands {
       ];
       $index_id = $value['id'] . '_' . uniqid();
       $value['id'] = $index_id;
+
+      // if default search server is set us 'pantheon_sol8' in settings.php,
+      // use  pantheon_solr 8 , otherwise  use  pantheon_search
+      $value['server'] = $this->endpoint->getDefaultSearchServer();
+      $value['dependencies']['config'] = [
+        'search_api.server.' . $value['server'],
+      ];
+      $this->logger->notice("Creating temporary index using server: " . $value['server']);
+
       $filesystem = \Drupal::service('file_system');
       $directory = 'temporary://' . $index_id;
       $filesystem = $filesystem->prepareDirectory($directory, FileSystemInterface:: CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
@@ -161,6 +170,7 @@ class TestIndexAndQuery extends DrushCommands {
       "If there's an issue with Solr, it would have shown up here. You should be good to go!"
     );
   }
+
 
   /**
    * Pings the Solr host.

--- a/src/Services/Endpoint.php
+++ b/src/Services/Endpoint.php
@@ -265,7 +265,7 @@ class Endpoint extends SolariumEndpoint {
    * @return string|null
    *   The default search server name.
    */
-  public  static function getDefaultSearchServer(): ?string {
+  public static function getDefaultSearchServer(): ?string {
     return Settings::get('default_search_server', self::DEFAULT_NAME);
   }
 

--- a/src/Services/Endpoint.php
+++ b/src/Services/Endpoint.php
@@ -265,7 +265,7 @@ class Endpoint extends SolariumEndpoint {
    * @return string|null
    *   The default search server name.
    */
-  public function getDefaultSearchServer(): ?string {
+  public  static function getDefaultSearchServer(): ?string {
     return Settings::get('default_search_server', self::DEFAULT_NAME);
   }
 


### PR DESCRIPTION
**Fixes added for drush commands**

` drush search-api-pantheon:postSchema`
Fixes issue with PostSchema Command when passed without argument
https://github.com/pantheon-systems/search_api_pantheon/pull/226
https://getpantheon.atlassian.net/browse/SITE-5117

`drush search-api-pantheon:force-cleanup`
The command previously supported only the pantheon_search server when no argument was provided. It has been updated to support pantheon_solr8 , if default search server is set as pantheon_solr8 in settings.php

`drush search-api-pantheon:test-index-and-query`

This command is fetching server and config values from this config file https://github.com/pantheon-systems/search_api_pantheon/blob/8.x/.ci/config/search_api.index.solr_index.yml
(https://github.com/pantheon-systems/search_api_pantheon/blob/c4108731ff28b87a32aed0520acaadf4654d3777/src/Commands/TestIndexAndQuery.php#L86)
  
So updated the code to support pantheon_solr 8,  if default search server is set as pantheon_solr8 in settings.php

<img width="1643" height="530" alt="Screenshot 2025-07-25 at 3 19 25 PM" src="https://github.com/user-attachments/assets/ae8da96a-2791-4d41-aee7-d42f1562fd5e" />

