### PR TITLE
[SITE-5266] perf: Move kint-php/kint to dev dependencies to eliminate production overhead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
         "ext-zip": "*",
         "drupal/search_api_solr": "^4.3",
         "guzzlehttp/guzzle": "^7.5",
-        "kint-php/kint": "^5|^6",
         "php-http/guzzle7-adapter": "^1.1",
         "psr/event-dispatcher": "^1.0",
         "symfony/finder": "^4.4|^5|^6|^7",
@@ -55,14 +54,14 @@
         "drupal/coder": "@stable",
         "phpunit/phpunit": "@stable",
         "psy/psysh": "@stable",
-        "squizlabs/php_codesniffer": "@stable"
+        "squizlabs/php_codesniffer": "@stable",
+        "kint-php/kint": "^5|^6"
     },
     "suggest":{
         "drupal/search_api_autocomplete": "^1",
         "drupal/search_api_spellcheck": "^3",
         "drupal/search_api_page": "^1.0",
-        "drupal/facets": "^1.8",
-        "kint-php/kint": "@stable"
+        "drupal/facets": "^1.8"
     },
     "scripts": {
         "code:test" : [


### PR DESCRIPTION
## Summary

This PR moves  from runtime dependencies () to development dependencies () to eliminate significant performance overhead in production environments.

## Problem

Kint is currently loaded on every request in production, causing:
- **~27ms execution time** per request for composer metadata parsing
- **~3MB memory usage** for parsing 300+ package metadata 
- **Runs before Drupal caching** mechanisms can intercept

This overhead occurs because Kint's  file automatically parses  and  files to look for configuration, which happens during Composer's autoload process on every request.

## Solution

- **Move**  from  to  section
- **Remove** duplicate  entry from  section
- **Preserve** all debugging functionality in development environments
- **Eliminate** production overhead when using 

## Impact

### Production (with )
✅ **Eliminates ~27ms + 3MB overhead per request**  
✅ **No functionality loss** (Kint shouldn't be in production)  
✅ **Faster page loads** and reduced memory usage

### Development (with dev dependencies)  
✅ **Kint remains fully available** for debugging  
✅ **No breaking changes** to development workflow  
✅ **All existing functionality preserved**

## Testing

- [x] Verified no runtime code uses Kint (only dev/test commands)
- [x] Confirmed RoboFile.php and Drush commands are dev-only tools
- [x] Tested that core module functionality is unaffected

## Performance Evidence

This change addresses a performance bottleneck identified via XDebug profiling where Kint's JSON parsing of composer metadata was consuming significant resources on every request before any application-level caching could help.

## Breaking Changes

None for typical usage. Only affects environments that:
1. Use  (production)  
2. AND try to use Kint debugging functions

Such usage would be incorrect anyway as debugging tools shouldn't be used in production.