### PR TITLE
Add support for Apache Solr 9

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,24 @@
+Search API Pantheon 8.4.0
+--------------------------------------------------
+This release adds support for Apache Solr 9 while maintaining backward compatibility with Solr 8.
+
+### What's New
+
+- Added support for Apache Solr 9.x
+- Updated version check in diagnose command to accept both Solr 8 and Solr 9
+- Updated documentation with Solr 9 upgrade instructions
+
+### Upgrading to Solr 9
+
+If you are upgrading from Solr 8 to Solr 9:
+
+1. Update your pantheon.yml to set `search.version: 9`
+2. Update your Search API server configuration to set solr_version to '9'
+3. Re-post the schema using `drush search-api-pantheon:postSchema`
+4. Reindex your content
+
+See README.md for detailed upgrade instructions.
+
 Search API Pantheon 8.3.4
 --------------------------------------------------
 This release addresses issues from version 8.3.3 and includes bug fix and improvements to Drush commands provided by the search_api_pantheon module:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Search API Pantheon: Solr 8 & Drupal 9.4+ Integration
+# Search API Pantheon: Solr 8/9 & Drupal 9.4+ Integration
 
 [![Search API Pantheon](https://github.com/pantheon-systems/search_api_pantheon/actions/workflows/ci.yml/badge.svg?branch=8.x)](https://github.com/pantheon-systems/search_api_pantheon/actions/workflows/ci.yml)
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#actively-maintained-support)
@@ -35,7 +35,7 @@ Search API Solr provides the ability to connect to any Solr server by providing 
 
 ## What it provides
 
-This module provides [Drupal 9.4+](https://drupal.org) integration with the [Apache Solr project](https://solr.apache.org/guide/8_8/). Pantheon's current version as of the update of this document is 8.11.4.
+This module provides [Drupal 9.4+](https://drupal.org) integration with [Apache Solr](https://solr.apache.org/). Supported Solr versions are 8.x and 9.x.
 
 ## Composer
 
@@ -78,13 +78,13 @@ To configure the connection with Pantheon, perform the following steps on your D
     This feature is available for sandbox sites as well as paid plans at the
     Professional level and above.
 
-#### Enable Solr 8 in your pantheon.yml file
+#### Enable Solr in your pantheon.yml file
 
   - Add or update the following in your `pantheon.yml` file:
 
     ```yaml
     search:
-      version: 8
+      version: 8  # or version: 9 for Solr 9
     ```
 
     As you promote the code, the `pantheon.yml` file will follow the code through environments
@@ -132,10 +132,9 @@ drush search-api-pantheon:reload
 
 #### Solr versions and schemas
 
-  - The version of Solr on Pantheon is Apache Solr 8.8. When you first create
-    your index or alter it significantly, you will need to update the SCHEMA
-    on the server. Do that either with a drush command or in the administration
-    for the Solr Server.
+  - When you first create your index or alter it significantly, you will need
+    to update the SCHEMA on the server. Do that either with a drush command or
+    in the administration for the Solr Server.
   - Navigate to `CONFIGURATION` => `SEARCH AND METADATA` => `SEARCH API`
     => `PANTHEON SEARCH` => `PANTHEON SEARCH ADMIN`
   - Choose the button labeled "Post Solr Schema".
@@ -239,9 +238,41 @@ The current default schema on Pantheon when a new Solr container is provisioned 
 
 `drush search-api-pantheon:postSchema pantheon_search /code/web/modules/contrib/search_api_solr/jump-start/solr8/config-set/`
 
+For Solr 9, use the solr9 config-set path:
+
+`drush search-api-pantheon:postSchema pantheon_search /code/web/modules/contrib/search_api_solr/jump-start/solr9/config-set/`
+
 Once you have enabled the Search API Pantheon module, when you reload the schema the Pantheon module will use the config-set for the version of the Search API Solr module installed in your codebase. See the [Search API Solr 4.3.0 release notes](https://www.drupal.org/project/search_api_solr/releases/4.3.0) for more information about upgrading to a 4.3.0+ compatible schema.
 
-- `drush search-api-pantheon:test-index-and-query` (`sap-tiq`) This command will connect to the solr8 server to index a single item and immediately query it.
+- `drush search-api-pantheon:test-index-and-query` (`sap-tiq`) This command will connect to the Solr server to index a single item and immediately query it.
+
+## Upgrading from Solr 8 to Solr 9
+
+If you are currently using Solr 8 and want to upgrade to Solr 9, follow these steps:
+
+1. **Update pantheon.yml**: Change the search version in your `pantheon.yml` file:
+   ```yaml
+   search:
+     version: 9
+   ```
+
+2. **Update server configuration**: In the Drupal admin UI, go to:
+   - Configuration → Search and metadata → Search API → Pantheon Search → Edit
+   - Update the "Solr version" setting to "9"
+   - Save the configuration
+
+3. **Re-post the schema**: Run the following drush command to upload the Solr 9 schema:
+   ```bash
+   drush search-api-pantheon:postSchema pantheon_search
+   ```
+
+4. **Reindex content**: After the schema is updated, reindex your content:
+   ```bash
+   drush search-api:reset-tracker
+   drush search-api:index
+   ```
+
+**Note**: Solr 9 introduces some breaking changes from Solr 8. Review the [Apache Solr 9 upgrade notes](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html) for details.
 
 ## Feedback and Collaboration
 

--- a/src/Commands/Diagnose.php
+++ b/src/Commands/Diagnose.php
@@ -51,7 +51,7 @@ class Diagnose extends DrushCommands {
    * Search_api_pantheon:diagnose.
    *
    * @usage search-api-pantheon:diagnose
-   *   Connect to the solr8 server.
+   *   Connect to the Solr server and diagnose the connection.
    *
    * @command search-api-pantheon:diagnose
    * @aliases sapd
@@ -94,8 +94,9 @@ class Diagnose extends DrushCommands {
         throw new \Exception('Unable to find search.version in pantheon.yml or pantheon.upstream.yml');
       }
 
-      if ($pantheon_yml['search']['version'] != '8') {
-        throw new \Exception('Unsupported search.version in pantheon.yml or pantheon.upstream.yml');
+      $supported_versions = ['8', '9'];
+      if (!in_array((string) $pantheon_yml['search']['version'], $supported_versions, true)) {
+        throw new \Exception('Unsupported search.version in pantheon.yml or pantheon.upstream.yml. Supported versions: ' . implode(', ', $supported_versions));
       }
       $this->logger->notice('Pantheon.yml file looks ok ✅');
 

--- a/src/Commands/TestIndexAndQuery.php
+++ b/src/Commands/TestIndexAndQuery.php
@@ -55,7 +55,7 @@ class TestIndexAndQuery extends DrushCommands {
    * Search_api_pantheon:test-index-and-query.
    *
    * @usage search-api-pantheon:test-index-and-query
-   *   Connect to the solr8 server to index a single item and immediately query it.
+   *   Connect to the Solr server to index a single item and immediately query it.
    *
    * @command search-api-pantheon:test-index-and-query
    * @aliases sap-tiq

--- a/src/Services/Endpoint.php
+++ b/src/Services/Endpoint.php
@@ -12,12 +12,12 @@ use Solarium\Core\Client\Endpoint as SolariumEndpoint;
  * Custom Endpoint class for Solarium.
  *
  * This class assembles environment variables into URL's for
- * the Pantheon Solr8 implementation.
+ * the Pantheon Solr implementation.
  *
- * URL Pattern for SOLR 8 QUERIES:
+ * URL Pattern for SOLR QUERIES:
  *  "$SCHEME://$HOST:$PORT/$PATH/$CORE"
  *
- * URL Pattern for SOLR 8 SCHEMA UPLOADS:
+ * URL Pattern for SOLR SCHEMA UPLOADS:
  *  "$SCHEME://$HOST:$PORT/$PATH/$SCHEMA"
  *
  * @package Drupal\search_api_pantheon

--- a/src/Services/SchemaPoster.php
+++ b/src/Services/SchemaPoster.php
@@ -262,7 +262,7 @@ class SchemaPoster implements LoggerAwareInterface {
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    */
-  public function getSolrFiles(string $server_id = 'pantheon_solr8') {
+  public function getSolrFiles(string $server_id = 'pantheon_search') {
     /** @var \Drupal\search_api\ServerInterface $server */
     $server = $this->entityTypeManager
       ->getStorage('search_api_server')


### PR DESCRIPTION
## Summary

- Add support for Apache Solr 9 while maintaining backward compatibility with Solr 8
- Update version check in diagnose command to accept both Solr 8 and 9
- Fix legacy default parameter in SchemaPoster from 'pantheon_solr8' to 'pantheon_search'
- Add comprehensive upgrade documentation for users migrating from Solr 8 to Solr 9

## Changes

| File | Change |
|------|--------|
| `src/Commands/Diagnose.php` | Accept Solr versions 8 and 9 in version check |
| `src/Services/SchemaPoster.php` | Update default server ID parameter |
| `src/Commands/TestIndexAndQuery.php` | Update docblock comment |
| `src/Services/Endpoint.php` | Update class docblock |
| `README.md` | Add Solr 9 documentation and upgrade instructions |
| `CHANGELOG.txt` | Add 8.4.0 release notes |

## Migration Approach

Users upgrading from Solr 8 to Solr 9 will need to:
1. Update `pantheon.yml` to set `search.version: 9`
2. Update their Search API server configuration to set `solr_version: '9'`
3. Re-post the schema using `drush search-api-pantheon:postSchema`
4. Reindex content

## Test plan

- [ ] Verify existing Solr 8 configurations continue to work
- [ ] Test diagnose command accepts both version 8 and 9
- [ ] Test schema posting with Solr 9 configuration
- [ ] Run CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)