### PR TITLE
[SITE-5499] Add fixes for Version 8.4.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,12 +5,11 @@ Search API Pantheon 8.4.1
 
 - The search_api_pantheon_admin submodule has been restored as an empty,
   deprecated module to prevent 'missing module' warnings during upgrades.
-  Sites that had this submodule installed prior to 8.4.0 will no longer see warnings.
-
+  An update hook will automatically uninstall the search_api_pantheon_admin submodule
+  if it was not manually uninstalled.
 
 ### Upgrade Instructions
 
-**From 8.3.x to 8.4.x:**
 1. Back up database
 
 2. Uninstall search_api_pantheon_admin submodule (if installed):

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,12 +1,18 @@
 Search API Pantheon 8.4.1
 --------------------------------------------------
 
+This is a patch release. All features and changes from 8.4.0 remain in effect.
+
+⚠️ IMPORTANT: If upgrading from 8.2.x or 8.3.x, please review the 8.4.0 section
+below for major architectural changes and breaking changes. All features, changes and
+requirements from 8.4.0 still apply.
+
 ### What's Changed
 
-- The search_api_pantheon_admin submodule has been restored as an empty,
-  deprecated module to prevent 'missing module' warnings during upgrades.
-  An update hook will automatically uninstall the search_api_pantheon_admin submodule
-  if it was not manually uninstalled.
+- The search_api_pantheon_admin submodule (removed in 8.4.0) has been restored
+  as an empty, obsolete module to ensure smooth upgrades from 8.3.x.
+  An update hook will automatically uninstall it if not manually uninstalled
+  beforehand.
 
 ### Upgrade Instructions
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,11 +1,9 @@
 Search API Pantheon 8.4.1
 --------------------------------------------------
 
-This is a patch release. All features and changes from 8.4.0 remain in effect.
-
-⚠️ IMPORTANT: If upgrading from 8.2.x or 8.3.x, please review the 8.4.0 section
-below for major architectural changes and breaking changes. All features, changes and
-requirements from 8.4.0 still apply.
+This is a patch release for 8.4.0. If upgrading from 8.2.x or 8.3.x,
+please review the 8.4.0 section below for major architectural changes and breaking
+changes. All features, changes and requirements from 8.4.0 still apply.
 
 ### What's Changed
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,50 @@
+Search API Pantheon 8.4.1
+--------------------------------------------------
+
+### What's Changed
+
+- The search_api_pantheon_admin submodule has been restored as an empty,
+  deprecated module to prevent 'missing module' warnings during upgrades.
+  Sites that had this submodule installed prior to 8.4.0 will no longer see warnings.
+
+
+### Upgrade Instructions
+
+**From 8.3.x to 8.4.x:**
+1. Back up database
+
+2. Uninstall search_api_pantheon_admin submodule (if installed):
+   drush pm:uninstall search_api_pantheon_admin
+
+3. Update the module:
+   composer require 'drupal/search_api_pantheon:^8.4'
+
+4. (Optional) Skip search server migration (available since 8.3.x):
+   To keep using 'pantheon_solr8' search server, add the following to settings.php
+   before running database updates:
+   $settings['default_search_server'] = 'pantheon_solr8';
+
+5. Run database updates:
+   drush updb
+
+6. Export configuration:
+   drush cex
+
+7. Clear cache:
+   drush cr
+
+8. Reindex content (Required only if search server was migrated):
+   Admin UI: admin/config/search/search-api → select index → "Index now"
+   Drush: drush search-api:index <INDEX_NAME>
+
+9. Update custom code (if applicable):
+   Update any custom code referencing 'pantheon_solr8' to use 'pantheon_search'
+
+10. Test search functionality thoroughly before deploying to live site
+
+Please read README.md before proceeding with installation or upgrade:
+https://git.drupalcode.org/project/search_api_pantheon/-/blob/8.4.x/README.md
+
 Search API Pantheon 8.4.0
 --------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -247,12 +247,17 @@ drush search-api-pantheon:reload
    - Migrates all indexes previously linked to 'pantheon_solr8' to use the new 'pantheon_search' server
    - Flags existing indexed items for reindexing
 
-4. **Clear cache:**
+4. **Export configuration:**
+   ```bash
+   drush cex
+   ```
+
+5. **Clear cache:**
    ```bash
    drush cr
    ```
 
-5. **Reindex content (Required only if search server was migrated):**
+6. **Reindex content (Required only if search server was migrated):**
 
    **Admin UI:**
    - Go to admin/config/search/search-api
@@ -263,14 +268,9 @@ drush search-api-pantheon:reload
    drush search-api:index [INDEX_NAME]
    ```
 
-6. **Update custom code (if applicable):**
+7. **Update custom code (if applicable):**
 
    Update any custom code referencing the old 'pantheon_solr8' server to use 'pantheon_search' instead.
-
-7. **Export configuration:**
-   ```bash
-   drush cex
-   ```
 
 8. **Test search functionality** thoroughly on non-production environments before deploying to live site.
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ drush search-api-pantheon:reload
 
 - Pantheon-specific endpoint functionality is moved into the connector, resulting in a 60% reduction in code length.
 
-- The search_api_pantheon_admin submodule has been removed. Its sole functionality (posting the schema) is already provided by the `drush search-api-pantheon:postSchema` command.
+- The search_api_pantheon_admin submodule is now obsolete. Its sole functionality (posting the schema) is already provided by the `drush search-api-pantheon:postSchema` command.
 
 #### Configuration and Local Development
 
@@ -210,21 +210,29 @@ drush search-api-pantheon:reload
 
 - Avoid passing server_id in drush [diagnostic commands](#diagnostic-commands) as it is no longer needed or accepted.
 
-### ⚠️ Important Steps Before Upgrading to 8.4.0
+### ⚠️ Important Steps Before Upgrading to 8.4.x
 
 1. **Backup your database** - The upgrade can make changes to your database and configuration.
-2. **Uninstall search_api_pantheon_admin (if installed)** - This submodule has been removed in 8.4.x.
+2. **Uninstall search_api_pantheon_admin (if installed)** - This submodule is obsolete as of 8.4.x.
     Before updating the module to 8.4.x, uninstall the search_api_pantheon_admin submodule by running:
 
    ```bash
-   drush pm:uninstall search_api_pantheon_admin
+   drush pm:uninstall search_api_pantheon_admin   # Uninstall the Admin Sub module
+   drush cex                                      # Export configuration
    ```
+
+Its sole functionality (posting the schema) is already provided by the `drush search-api-pantheon:postSchema` command.
 
 ### Step-by-Step Upgrade Process
 
 1. **Update via Composer:**
    ```bash
    composer require 'drupal/search_api_pantheon:^8.4'
+   ```
+
+   If you encounter errors related to removed hooks or classes, clear the cache:
+   ```bash
+   drush cr
    ```
 
 2. **(Optional) Skip search server migration:**

--- a/modules/search_api_pantheon_admin/search_api_pantheon_admin.info.yml
+++ b/modules/search_api_pantheon_admin/search_api_pantheon_admin.info.yml
@@ -1,0 +1,9 @@
+name: 'Search API Pantheon Admin (Deprecated)'
+type: module
+description: 'This module is deprecated in 8.4.x'
+core_version_requirement: ^10 || ^11
+package: Search
+dependencies:
+  - search_api_pantheon:search_api_pantheon
+lifecycle: deprecated
+lifecycle_link: 'https://git.drupalcode.org/project/search_api_pantheon/-/blob/8.4.x/CHANGELOG.txt'

--- a/modules/search_api_pantheon_admin/search_api_pantheon_admin.info.yml
+++ b/modules/search_api_pantheon_admin/search_api_pantheon_admin.info.yml
@@ -1,9 +1,9 @@
-name: 'Search API Pantheon Admin (Deprecated)'
+name: 'Search API Pantheon Admin'
 type: module
 description: 'This module is deprecated in 8.4.x'
 core_version_requirement: ^10 || ^11
 package: Search
 dependencies:
-  - search_api_pantheon:search_api_pantheon
+  - search_api_solr:search_api_solr
 lifecycle: deprecated
 lifecycle_link: 'https://git.drupalcode.org/project/search_api_pantheon/-/blob/8.4.x/CHANGELOG.txt'

--- a/modules/search_api_pantheon_admin/search_api_pantheon_admin.info.yml
+++ b/modules/search_api_pantheon_admin/search_api_pantheon_admin.info.yml
@@ -1,9 +1,9 @@
 name: 'Search API Pantheon Admin'
 type: module
-description: 'This module is deprecated in 8.4.x'
+description: 'This module is obsolete as of 8.4.x.'
 core_version_requirement: ^10 || ^11
 package: Search
 dependencies:
   - search_api_solr:search_api_solr
-lifecycle: deprecated
+lifecycle: obsolete
 lifecycle_link: 'https://git.drupalcode.org/project/search_api_pantheon/-/blob/8.4.x/CHANGELOG.txt'

--- a/modules/search_api_pantheon_admin/search_api_pantheon_admin.module
+++ b/modules/search_api_pantheon_admin/search_api_pantheon_admin.module
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @file
+ * Deprecated module - functionality moved to drush commands.
+ *
+ * This module is deprecated and will be removed in a future version.
+ * Use the drush search-api-pantheon:postSchema command instead.
+ *
+ * To uninstall: drush pm:uninstall search_api_pantheon_admin
+ */

--- a/search_api_pantheon.install
+++ b/search_api_pantheon.install
@@ -9,12 +9,10 @@ use Drupal\search_api\Entity\Server;
 use Drupal\Core\Site\Settings;
 
 /**
- * Remove deprecated search_api_pantheon_admin submodule entries.
+ * Uninstall deprecated search_api_pantheon_admin submodule.
  *
  * This update hook cleans up orphaned configuration entries for the
- * search_api_pantheon_admin submodule that is removed in 8.4.x.
- * If the submodule was not properly uninstalled before upgrading,
- * this will resolve "module missing" warnings for search_api_pantheon_admin submodule.
+ * search_api_pantheon_admin submodule that is deprecated in 8.4.x.
  */
 function search_api_pantheon_update_10080() {
   $config_factory = \Drupal::configFactory();


### PR DESCRIPTION
This PR implements fixes for Search API Pantheon version 8.4.0

### **Testing**

I tested the changes with '8.3.4' -> 'dev-8.4.x-updates'  upgrade.

### Changes Added

**Restored and updated the lifecycle of the Search API Admin module to 'obsolete.'**

_Obsolete extensions cannot be installed anymore and are kept only for backward compatibility with existing sites. They do not appear in the module listing page but remain available for uninstall._



For obsolete extensions, status page will show this warning
<img width="1728" height="435" alt="Screenshot 2026-02-06 at 1 44 04 PM" src="https://github.com/user-attachments/assets/c45f5696-e6bb-4cd0-a096-805c4ddbaf2d" />


 **Error after upgrading the module (before clearing cache)**

<img width="1657" height="894" alt="Screenshot 2026-02-04 at 6 20 32 PM" src="https://github.com/user-attachments/assets/397b01c0-7d0d-4016-a1a8-74c603105f0b" />

Update hook (For testing, adjusted  updatehook name in my local, since 10080 was already run in my site)

<img width="1209" height="707" alt="Screenshot 2026-02-04 at 6 28 58 PM" src="https://github.com/user-attachments/assets/d95ee15e-8c50-4775-91fe-ef0671699886" />

**Completed database updates and uninstalled the Search API Pantheon Admin module**

<img width="1206" height="676" alt="Screenshot 2026-02-04 at 6 29 21 PM" src="https://github.com/user-attachments/assets/18ce2599-c276-486a-afdb-0c1ea21862af" />
