### PR TITLE
ci: Add bootstrap script for CI fixture site recreation

### DIFF
--- a/.github/scripts/bootstrap-fixture-site.sh
+++ b/.github/scripts/bootstrap-fixture-site.sh
@@ -11,10 +11,9 @@ set -eou pipefail
 #   1. Pantheon site on correct upstream + Drupal install
 #   2. Performance Small plan + Solr enabled
 #   3. pantheon.yml with Solr 8 and PHP version
-#   4. Test/live environments deployed
-#   5. field_test content type with 10 fields
-#   6. "Field Mapping Test Node" with known values
-#   7. Verification
+#   4. field_test content type with 10 fields
+#   5. "Field Mapping Test Node" with known values
+#   6. Verification
 #
 # Examples:
 #   .github/scripts/bootstrap-fixture-site.sh -n search-api-pantheon-d10 -u d10
@@ -91,16 +90,17 @@ main() {
     echo ""
 
     # -----------------------------------------------------------------------
-    # Step 1: Create site (skip if exists)
+    # Step 1: Create site (exit if exists)
     # -----------------------------------------------------------------------
     if terminus site:info "$SITE_NAME_LC" &>/dev/null; then
-        echo "[skip] Site ${SITE_NAME} already exists"
-    else
-        echo "[1/7] Creating site..."
-        terminus site:create "$SITE_NAME" "$SITE_NAME" "$UPSTREAM" --org="$ORG"
-        echo "Waiting for site creation workflow..."
-        terminus workflow:wait "$SITE_ENV" --max=600
+        echo "ERROR: Site ${SITE_NAME} already exists. Exiting to avoid modifying an existing site."
+        exit 1
     fi
+
+    echo "[1/6] Creating site..."
+    terminus site:create "$SITE_NAME" "$SITE_NAME" "$UPSTREAM" --org="$ORG"
+    echo "Waiting for site creation workflow..."
+    terminus workflow:wait "$SITE_ENV"
 
     local SITE_ID
     SITE_ID=$(terminus site:info "$SITE_NAME_LC" --field=ID)
@@ -108,7 +108,7 @@ main() {
     # -----------------------------------------------------------------------
     # Step 2: Install Drupal
     # -----------------------------------------------------------------------
-    echo "[2/7] Installing Drupal..."
+    echo "[2/6] Installing Drupal..."
     if terminus drush "$SITE_ENV" -- status --field=bootstrap 2>/dev/null | grep -q "Successful"; then
         echo "[skip] Drupal already installed"
     else
@@ -118,7 +118,7 @@ main() {
     # -----------------------------------------------------------------------
     # Step 3: Upgrade plan + enable Solr
     # -----------------------------------------------------------------------
-    echo "[3/7] Configuring plan and Solr..."
+    echo "[3/6] Configuring plan and Solr..."
     local CURRENT_PLAN
     CURRENT_PLAN=$(terminus site:info "$SITE_NAME_LC" --field=plan_name 2>/dev/null || echo "")
     if [[ "$CURRENT_PLAN" == *"Sandbox"* ]]; then
@@ -134,7 +134,7 @@ main() {
     # -----------------------------------------------------------------------
     # Step 4: Configure pantheon.yml (Solr 8, PHP version)
     # -----------------------------------------------------------------------
-    echo "[4/7] Configuring pantheon.yml..."
+    echo "[4/6] Configuring pantheon.yml..."
 
     local GIT_URL
     GIT_URL=$(terminus connection:info "$SITE_ENV" --field=git_url)
@@ -144,15 +144,30 @@ main() {
 
     pushd "$WORK_DIR/site" > /dev/null
 
+    echo "Current pantheon.yml:"
+    if [ -f pantheon.yml ]; then
+        cat pantheon.yml
+    else
+        echo "(file does not exist)"
+    fi
+    echo "---"
+
     if [ -f pantheon.yml ]; then
         if ! grep -q "^search:" pantheon.yml; then
+            echo "Adding search config..."
             echo "search:" >> pantheon.yml
             echo "  version: 8" >> pantheon.yml
+        else
+            echo "search: already present"
         fi
         if ! grep -q "php_version:" pantheon.yml; then
+            echo "Adding php_version: ${PHP_VER}..."
             echo "php_version: ${PHP_VER}" >> pantheon.yml
+        else
+            echo "php_version: already present ($(grep php_version pantheon.yml))"
         fi
     else
+        echo "Creating pantheon.yml from scratch..."
         cat > pantheon.yml <<YAML
 api_version: 1
 php_version: ${PHP_VER}
@@ -161,13 +176,19 @@ search:
 YAML
     fi
 
+    echo "Updated pantheon.yml:"
+    cat pantheon.yml
+    echo "---"
+
     if git diff --quiet pantheon.yml 2>/dev/null; then
-        echo "[skip] pantheon.yml already configured"
+        echo "[skip] No changes to pantheon.yml"
     else
+        echo "Changes detected:"
+        git diff pantheon.yml
         git add pantheon.yml
         git commit -m "Configure Solr 8 and PHP ${PHP_VER} for CI fixture"
         git push origin master
-        terminus workflow:wait "$SITE_ENV" --max=300
+        terminus workflow:wait "$SITE_ENV"
     fi
 
     popd > /dev/null
@@ -195,16 +216,9 @@ YAML
     done
 
     # -----------------------------------------------------------------------
-    # Step 5: Deploy test and live environments
+    # Step 5: Create field_test content type, fields, and test node
     # -----------------------------------------------------------------------
-    echo "[5/7] Deploying test and live environments..."
-    terminus env:deploy --cc --updatedb "${SITE_ID}.test" 2>/dev/null || echo "[skip] Test env already deployed or nothing to deploy"
-    terminus env:deploy --cc --updatedb "${SITE_ID}.live" 2>/dev/null || echo "[skip] Live env already deployed or nothing to deploy"
-
-    # -----------------------------------------------------------------------
-    # Step 6: Create field_test content type, fields, and test node
-    # -----------------------------------------------------------------------
-    echo "[6/7] Creating field_test content type, fields, and test node..."
+    echo "[5/6] Creating field_test content type, fields, and test node..."
 
     terminus drush "$SITE_ENV" -- ev "
       \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');
@@ -301,7 +315,7 @@ YAML
     # -----------------------------------------------------------------------
     # Step 7: Verify setup
     # -----------------------------------------------------------------------
-    echo "[7/7] Verifying setup..."
+    echo "[6/6] Verifying setup..."
 
     terminus drush "$SITE_ENV" -- ev "
       \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');

--- a/.github/scripts/bootstrap-fixture-site.sh
+++ b/.github/scripts/bootstrap-fixture-site.sh
@@ -9,11 +9,12 @@ set -euo pipefail
 #
 # What it sets up:
 #   1. Pantheon site on drupal-composer-managed upstream (CI Fixtures org)
-#   2. pantheon.yml with Solr 8 and PHP version (8.1 for D10, 8.3 for D11)
-#   3. field_test content type with 10 fields (string, text_long, integer,
+#   2. Drupal install (standard profile)
+#   3. pantheon.yml with Solr 8 and PHP version (8.1 for D10, 8.3 for D11)
+#   4. field_test content type with 10 fields (string, text_long, integer,
 #      boolean, email, link, decimal, datetime/date, datetime/datetime, list_string)
-#   4. "Field Mapping Test Node" with known values for all 10 fields
-#   5. Verification that everything was created correctly
+#   5. "Field Mapping Test Node" with known values for all 10 fields
+#   6. Verification that everything was created correctly
 #
 # How to use:
 #   1. Authenticate terminus:
@@ -58,16 +59,23 @@ echo ""
 if terminus site:info "$SITE_NAME" &>/dev/null; then
   echo "[skip] Site ${SITE_NAME} already exists"
 else
-  echo "[1/5] Creating site..."
+  echo "[1/6] Creating site..."
   terminus site:create "$SITE_NAME" "$SITE_NAME" "$UPSTREAM" --org="$ORG"
   echo "Waiting for site creation workflow..."
   terminus workflow:wait "$SITE_ENV" --max=300
+
+  echo "Installing Drupal..."
+  terminus drush "$SITE_ENV" -- site:install standard \
+    --account-name=admin \
+    --account-mail=admin@test.com \
+    --site-name="$SITE_NAME" \
+    --yes
 fi
 
 # ---------------------------------------------------------------------------
 # Step 2: Configure pantheon.yml (Solr 8, PHP version)
 # ---------------------------------------------------------------------------
-echo "[2/5] Configuring pantheon.yml..."
+echo "[2/6] Configuring pantheon.yml..."
 
 GIT_URL=$(terminus connection:info "$SITE_ENV" --field=git_url)
 WORK_DIR=$(mktemp -d)
@@ -128,7 +136,7 @@ done
 # ---------------------------------------------------------------------------
 # Step 3: Create field_test content type and 10 fields
 # ---------------------------------------------------------------------------
-echo "[3/5] Creating field_test content type and fields..."
+echo "[3/6] Creating field_test content type and fields..."
 
 terminus drush "$SITE_ENV" -- ev "
   \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');
@@ -197,7 +205,7 @@ terminus drush "$SITE_ENV" -- ev "
 # ---------------------------------------------------------------------------
 # Step 4: Create test node with known field values
 # ---------------------------------------------------------------------------
-echo "[4/5] Creating test node..."
+echo "[4/6] Creating test node..."
 
 terminus drush "$SITE_ENV" -- ev "
   use Drupal\node\Entity\Node;
@@ -229,7 +237,7 @@ terminus drush "$SITE_ENV" -- ev "
 # ---------------------------------------------------------------------------
 # Step 5: Verify setup
 # ---------------------------------------------------------------------------
-echo "[5/5] Verifying setup..."
+echo "[5/6] Verifying setup..."
 
 terminus drush "$SITE_ENV" -- ev "
   \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');

--- a/.github/scripts/bootstrap-fixture-site.sh
+++ b/.github/scripts/bootstrap-fixture-site.sh
@@ -131,7 +131,7 @@ main() {
     fi
 
     echo "Enabling Solr..."
-    terminus solr:enable "$SITE_ID" 2>/dev/null || echo "[skip] Solr already enabled or enable failed"
+    terminus search:enable "$SITE_ID" 2>/dev/null || echo "[skip] Solr already enabled or enable failed"
 
     # Wait for Drupal to be available
     echo "Waiting for Drupal to be available..."

--- a/.github/scripts/bootstrap-fixture-site.sh
+++ b/.github/scripts/bootstrap-fixture-site.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env bash
+set -eou pipefail
 
 # Bootstrap a Search API Pantheon CI fixture site from scratch.
 #
@@ -8,278 +8,343 @@ set -euo pipefail
 # rebuilt from zero. All steps are idempotent (safe to re-run).
 #
 # What it sets up:
-#   1. Pantheon site on drupal-composer-managed upstream (CI Fixtures org)
-#   2. Drupal install (standard profile)
-#   3. pantheon.yml with Solr 8 and PHP version (8.1 for D10, 8.3 for D11)
-#   4. field_test content type with 10 fields (string, text_long, integer,
-#      boolean, email, link, decimal, datetime/date, datetime/datetime, list_string)
-#   5. "Field Mapping Test Node" with known values for all 10 fields
-#   6. Verification that everything was created correctly
-#
-# How to use:
-#   1. Authenticate terminus:
-#        terminus auth:login --machine-token=<token>
-#   2. Load your SSH key:
-#        ssh-add ~/.ssh/id_rsa
-#   3. Set git identity:
-#        git config --global user.email "you@example.com"
-#        git config --global user.name "Your Name"
-#   4. Run the script from the repo root:
-#        .github/scripts/bootstrap-fixture-site.sh search-api-pantheon-d10 10
-#        .github/scripts/bootstrap-fixture-site.sh search-api-pantheon-d11 11
-#   5. Verify the dev site at:
-#        https://dev-<site-name>.pantheonsite.io
-#
-# Arguments:
-#   $1  site-name       Pantheon site machine name (e.g. search-api-pantheon-d10)
-#   $2  drupal-version  Drupal major version: 10 or 11
-#   $3  org-uuid        (optional) Pantheon org UUID. Defaults to CI Fixtures org.
+#   1. Pantheon site on correct upstream + Drupal install
+#   2. Performance Small plan + Solr enabled
+#   3. pantheon.yml with Solr 8 and PHP version
+#   4. Test/live environments deployed
+#   5. field_test content type with 10 fields
+#   6. "Field Mapping Test Node" with known values
+#   7. Verification
 #
 # Examples:
-#   .github/scripts/bootstrap-fixture-site.sh search-api-pantheon-d10 10
-#   .github/scripts/bootstrap-fixture-site.sh search-api-pantheon-d11 11
-#   .github/scripts/bootstrap-fixture-site.sh search-api-pantheon-d10 10 5ae1fa30-8cc4-4894-8ca9-d50628dcba17
+#   .github/scripts/bootstrap-fixture-site.sh -n search-api-pantheon-d10 -u d10
+#   .github/scripts/bootstrap-fixture-site.sh -n search-api-pantheon-d11 -u d11
+#   .github/scripts/bootstrap-fixture-site.sh -n search-api-pantheon-d10 -u d10 -o "CI Fixtures for Projects"
+#
+# Prerequisites:
+#   - terminus authenticated (terminus auth:whoami)
+#   - SSH key loaded for Pantheon git operations
+#   - git configured (user.email, user.name)
 
-SITE_NAME="${1:?Usage: $0 <site-name> <drupal-version> [org-uuid]}"
-DRUPAL_VERSION="${2:?Usage: $0 <site-name> <drupal-version> [org-uuid]}"
-ORG="${3:-5ae1fa30-8cc4-4894-8ca9-d50628dcba17}"  # CI Fixtures for Projects
+show_help() {
+    echo "Usage: $0 -n <site-name> -u <upstream> [-o <org>]"
+    echo "Options:"
+    echo "  -n <arg>         Site name (e.g. search-api-pantheon-d10)"
+    echo "  -u <arg>         Upstream: 'd10' or 'd11'"
+    echo "  -o <arg>         Organization name or UUID (default: CI Fixtures for Projects)"
+    echo "  -h               Show help"
+    exit 1
+}
 
-UPSTREAM="drupal-composer-managed"
-SITE_ENV="${SITE_NAME}.dev"
+main() {
+    local UPSTREAM=""
+    local SITE_NAME=""
+    local ORG="CI Fixtures for Projects"
 
-echo "=== Bootstrap CI Fixture Site ==="
-echo "Site: ${SITE_NAME}"
-echo "Drupal: ${DRUPAL_VERSION}"
-echo "Org: ${ORG}"
-echo ""
+    while getopts "u:o:n:h" opt; do
+        case $opt in
+            u) UPSTREAM="$OPTARG" ;;
+            o) ORG="$OPTARG" ;;
+            n) SITE_NAME="$OPTARG" ;;
+            h) show_help ;;
+            *) show_help ;;
+        esac
+    done
 
-# ---------------------------------------------------------------------------
-# Step 1: Create site (skip if exists)
-# ---------------------------------------------------------------------------
-if terminus site:info "$SITE_NAME" &>/dev/null; then
-  echo "[skip] Site ${SITE_NAME} already exists"
-else
-  echo "[1/6] Creating site..."
-  terminus site:create "$SITE_NAME" "$SITE_NAME" "$UPSTREAM" --org="$ORG"
-  echo "Waiting for site creation workflow..."
-  terminus workflow:wait "$SITE_ENV" --max=300
+    shift "$((OPTIND-1))"
 
-  echo "Installing Drupal..."
-  terminus drush "$SITE_ENV" -- site:install standard \
-    --account-name=admin \
-    --account-mail=admin@test.com \
-    --site-name="$SITE_NAME" \
-    --yes
-fi
+    if [[ -z "$SITE_NAME" ]]; then
+        echo "ERROR: -n <site-name> is required"
+        show_help
+    fi
 
-# ---------------------------------------------------------------------------
-# Step 2: Configure pantheon.yml (Solr 8, PHP version)
-# ---------------------------------------------------------------------------
-echo "[2/6] Configuring pantheon.yml..."
+    if [[ -z "$UPSTREAM" ]]; then
+        echo "ERROR: -u <upstream> is required (d10 or d11)"
+        show_help
+    fi
 
-GIT_URL=$(terminus connection:info "$SITE_ENV" --field=git_url)
-WORK_DIR=$(mktemp -d)
-GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone "$GIT_URL" "$WORK_DIR/site"
-cd "$WORK_DIR/site"
+    local PHP_VER
+    case "$UPSTREAM" in
+        d10)
+            UPSTREAM="drupal-10-composer-managed"
+            PHP_VER="8.1"
+            ;;
+        d11)
+            UPSTREAM="drupal-11-composer-managed"
+            PHP_VER="8.3"
+            ;;
+        *)
+            echo "ERROR: Upstream must be 'd10' or 'd11', got: ${UPSTREAM}"
+            show_help
+            ;;
+    esac
 
-if [ "$DRUPAL_VERSION" = "10" ]; then
-  PHP_VER="8.1"
-elif [ "$DRUPAL_VERSION" = "11" ]; then
-  PHP_VER="8.3"
-else
-  PHP_VER="8.3"
-fi
+    local SITE_NAME_LC
+    SITE_NAME_LC=$(echo "$SITE_NAME" | tr '[:upper:]' '[:lower:]')
+    local SITE_ENV="${SITE_NAME_LC}.dev"
 
-if [ -f pantheon.yml ]; then
-  if ! grep -q "^search:" pantheon.yml; then
-    echo "search:" >> pantheon.yml
-    echo "  version: 8" >> pantheon.yml
-  fi
-  if ! grep -q "php_version:" pantheon.yml; then
-    echo "php_version: ${PHP_VER}" >> pantheon.yml
-  fi
-else
-  cat > pantheon.yml <<YAML
+    echo "=== Bootstrap CI Fixture Site ==="
+    echo "Site: ${SITE_NAME}"
+    echo "Upstream: ${UPSTREAM}"
+    echo "PHP: ${PHP_VER}"
+    echo "Org: ${ORG}"
+    echo ""
+
+    # -----------------------------------------------------------------------
+    # Step 1: Create site (skip if exists)
+    # -----------------------------------------------------------------------
+    if terminus site:info "$SITE_NAME_LC" &>/dev/null; then
+        echo "[skip] Site ${SITE_NAME} already exists"
+    else
+        echo "[1/7] Creating site..."
+        terminus site:create "$SITE_NAME" "$SITE_NAME" "$UPSTREAM" --org="$ORG"
+        echo "Waiting for site creation workflow..."
+        terminus workflow:wait "$SITE_ENV" --max=600
+    fi
+
+    local SITE_ID
+    SITE_ID=$(terminus site:info "$SITE_NAME_LC" --field=ID)
+
+    # -----------------------------------------------------------------------
+    # Step 2: Install Drupal
+    # -----------------------------------------------------------------------
+    echo "[2/7] Installing Drupal..."
+    if terminus drush "$SITE_ENV" -- status --field=bootstrap 2>/dev/null | grep -q "Successful"; then
+        echo "[skip] Drupal already installed"
+    else
+        terminus drush "$SITE_ENV" -- site-install -y
+    fi
+
+    # -----------------------------------------------------------------------
+    # Step 3: Upgrade plan + enable Solr
+    # -----------------------------------------------------------------------
+    echo "[3/7] Configuring plan and Solr..."
+    local CURRENT_PLAN
+    CURRENT_PLAN=$(terminus site:info "$SITE_NAME_LC" --field=plan_name 2>/dev/null || echo "")
+    if [[ "$CURRENT_PLAN" == *"Sandbox"* ]]; then
+        echo "Upgrading to Performance Small..."
+        terminus plan:set "$SITE_ID" "plan-performance_small-contract-annual-1"
+    else
+        echo "[skip] Already on plan: ${CURRENT_PLAN}"
+    fi
+
+    echo "Enabling Solr..."
+    terminus solr:enable "$SITE_ID" 2>/dev/null || echo "[skip] Solr already enabled or enable failed"
+
+    # -----------------------------------------------------------------------
+    # Step 4: Configure pantheon.yml (Solr 8, PHP version)
+    # -----------------------------------------------------------------------
+    echo "[4/7] Configuring pantheon.yml..."
+
+    local GIT_URL
+    GIT_URL=$(terminus connection:info "$SITE_ENV" --field=git_url)
+    local WORK_DIR
+    WORK_DIR=$(mktemp -d)
+    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone "$GIT_URL" "$WORK_DIR/site"
+
+    pushd "$WORK_DIR/site" > /dev/null
+
+    if [ -f pantheon.yml ]; then
+        if ! grep -q "^search:" pantheon.yml; then
+            echo "search:" >> pantheon.yml
+            echo "  version: 8" >> pantheon.yml
+        fi
+        if ! grep -q "php_version:" pantheon.yml; then
+            echo "php_version: ${PHP_VER}" >> pantheon.yml
+        fi
+    else
+        cat > pantheon.yml <<YAML
 api_version: 1
 php_version: ${PHP_VER}
 search:
   version: 8
 YAML
-fi
+    fi
 
-if git diff --quiet pantheon.yml; then
-  echo "[skip] pantheon.yml already configured"
-else
-  git add pantheon.yml
-  git commit -m "Configure Solr 8 and PHP ${PHP_VER} for CI fixture"
-  git push origin master
-  terminus workflow:wait "$SITE_ENV" --max=300
-fi
+    if git diff --quiet pantheon.yml 2>/dev/null; then
+        echo "[skip] pantheon.yml already configured"
+    else
+        git add pantheon.yml
+        git commit -m "Configure Solr 8 and PHP ${PHP_VER} for CI fixture"
+        git push origin master
+        terminus workflow:wait "$SITE_ENV" --max=300
+    fi
 
-cd /tmp
-rm -rf "$WORK_DIR"
+    popd > /dev/null
+    rm -rf "$WORK_DIR"
 
-# Wait for environment to be ready after code push
-echo "Waiting for Drupal to be available..."
-for i in $(seq 1 12); do
-  if terminus drush "$SITE_ENV" -- status --field=bootstrap 2>/dev/null | grep -q "Successful"; then
-    echo "Drupal ready"
-    break
-  fi
-  if [ "$i" -eq 12 ]; then
-    echo "ERROR: Drupal not ready after 2 minutes"
-    exit 1
-  fi
-  sleep 10
-done
+    # Ensure connection mode is git
+    local CONNECTION_TYPE
+    CONNECTION_TYPE=$(terminus env:info "$SITE_ENV" --field="Connection Mode" 2>/dev/null || echo "")
+    if [[ "$CONNECTION_TYPE" != "git" ]]; then
+        terminus connection:set "$SITE_ENV" git
+    fi
 
-# ---------------------------------------------------------------------------
-# Step 3: Create field_test content type and 10 fields
-# ---------------------------------------------------------------------------
-echo "[3/6] Creating field_test content type and fields..."
+    # Wait for Drupal to be available
+    echo "Waiting for Drupal to be available..."
+    for i in $(seq 1 12); do
+        if terminus drush "$SITE_ENV" -- status --field=bootstrap 2>/dev/null | grep -q "Successful"; then
+            echo "Drupal ready"
+            break
+        fi
+        if [ "$i" -eq 12 ]; then
+            echo "ERROR: Drupal not ready after 2 minutes"
+            exit 1
+        fi
+        sleep 10
+    done
 
-terminus drush "$SITE_ENV" -- ev "
-  \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');
-  if (\$type) { echo 'field_test already exists, skipping' . PHP_EOL; return; }
-  \$type = \Drupal::entityTypeManager()->getStorage('node_type')->create([
-    'type' => 'field_test',
-    'name' => 'Field Test',
-  ]);
-  \$type->save();
-  echo 'Content type created' . PHP_EOL;
-"
+    # -----------------------------------------------------------------------
+    # Step 5: Deploy test and live environments
+    # -----------------------------------------------------------------------
+    echo "[5/7] Deploying test and live environments..."
+    terminus env:deploy --cc --updatedb "${SITE_ID}.test" 2>/dev/null || echo "[skip] Test env already deployed or nothing to deploy"
+    terminus env:deploy --cc --updatedb "${SITE_ID}.live" 2>/dev/null || echo "[skip] Live env already deployed or nothing to deploy"
 
-# Simple fields (no custom settings)
-SIMPLE_FIELDS="field_text_plain:string field_text_long:text_long field_integer:integer field_boolean:boolean field_email:email field_link:link"
+    # -----------------------------------------------------------------------
+    # Step 6: Create field_test content type, fields, and test node
+    # -----------------------------------------------------------------------
+    echo "[6/7] Creating field_test content type, fields, and test node..."
 
-for FIELD_DEF in $SIMPLE_FIELDS; do
-  FIELD_NAME="${FIELD_DEF%%:*}"
-  FIELD_TYPE="${FIELD_DEF##*:}"
-  terminus drush "$SITE_ENV" -- ev "
-    use Drupal\field\Entity\FieldStorageConfig;
-    use Drupal\field\Entity\FieldConfig;
-    if (FieldStorageConfig::loadByName('node', '${FIELD_NAME}')) { echo '${FIELD_NAME} exists' . PHP_EOL; return; }
-    FieldStorageConfig::create(['field_name' => '${FIELD_NAME}', 'entity_type' => 'node', 'type' => '${FIELD_TYPE}'])->save();
-    FieldConfig::create(['field_name' => '${FIELD_NAME}', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => '${FIELD_NAME}'])->save();
-    echo '${FIELD_NAME} created' . PHP_EOL;
-  "
-done
+    terminus drush "$SITE_ENV" -- ev "
+      \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');
+      if (\$type) { echo 'field_test already exists, skipping' . PHP_EOL; return; }
+      \$type = \Drupal::entityTypeManager()->getStorage('node_type')->create([
+        'type' => 'field_test',
+        'name' => 'Field Test',
+      ]);
+      \$type->save();
+      echo 'Content type created' . PHP_EOL;
+    "
 
-# Fields with custom settings
-terminus drush "$SITE_ENV" -- ev "
-  use Drupal\field\Entity\FieldStorageConfig;
-  use Drupal\field\Entity\FieldConfig;
-  if (FieldStorageConfig::loadByName('node', 'field_decimal')) { echo 'field_decimal exists' . PHP_EOL; return; }
-  FieldStorageConfig::create(['field_name' => 'field_decimal', 'entity_type' => 'node', 'type' => 'decimal', 'settings' => ['precision' => 10, 'scale' => 2]])->save();
-  FieldConfig::create(['field_name' => 'field_decimal', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_decimal'])->save();
-  echo 'field_decimal created' . PHP_EOL;
-"
+    # Simple fields (no custom settings)
+    local SIMPLE_FIELDS="field_text_plain:string field_text_long:text_long field_integer:integer field_boolean:boolean field_email:email field_link:link"
 
-terminus drush "$SITE_ENV" -- ev "
-  use Drupal\field\Entity\FieldStorageConfig;
-  use Drupal\field\Entity\FieldConfig;
-  if (FieldStorageConfig::loadByName('node', 'field_date')) { echo 'field_date exists' . PHP_EOL; return; }
-  FieldStorageConfig::create(['field_name' => 'field_date', 'entity_type' => 'node', 'type' => 'datetime', 'settings' => ['datetime_type' => 'date']])->save();
-  FieldConfig::create(['field_name' => 'field_date', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_date'])->save();
-  echo 'field_date created' . PHP_EOL;
-"
+    for FIELD_DEF in $SIMPLE_FIELDS; do
+        local FIELD_NAME="${FIELD_DEF%%:*}"
+        local FIELD_TYPE="${FIELD_DEF##*:}"
+        terminus drush "$SITE_ENV" -- ev "
+          use Drupal\field\Entity\FieldStorageConfig;
+          use Drupal\field\Entity\FieldConfig;
+          if (FieldStorageConfig::loadByName('node', '${FIELD_NAME}')) { echo '${FIELD_NAME} exists' . PHP_EOL; return; }
+          FieldStorageConfig::create(['field_name' => '${FIELD_NAME}', 'entity_type' => 'node', 'type' => '${FIELD_TYPE}'])->save();
+          FieldConfig::create(['field_name' => '${FIELD_NAME}', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => '${FIELD_NAME}'])->save();
+          echo '${FIELD_NAME} created' . PHP_EOL;
+        "
+    done
 
-terminus drush "$SITE_ENV" -- ev "
-  use Drupal\field\Entity\FieldStorageConfig;
-  use Drupal\field\Entity\FieldConfig;
-  if (FieldStorageConfig::loadByName('node', 'field_datetime')) { echo 'field_datetime exists' . PHP_EOL; return; }
-  FieldStorageConfig::create(['field_name' => 'field_datetime', 'entity_type' => 'node', 'type' => 'datetime', 'settings' => ['datetime_type' => 'datetime']])->save();
-  FieldConfig::create(['field_name' => 'field_datetime', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_datetime'])->save();
-  echo 'field_datetime created' . PHP_EOL;
-"
+    # Fields with custom settings
+    terminus drush "$SITE_ENV" -- ev "
+      use Drupal\field\Entity\FieldStorageConfig;
+      use Drupal\field\Entity\FieldConfig;
+      if (FieldStorageConfig::loadByName('node', 'field_decimal')) { echo 'field_decimal exists' . PHP_EOL; return; }
+      FieldStorageConfig::create(['field_name' => 'field_decimal', 'entity_type' => 'node', 'type' => 'decimal', 'settings' => ['precision' => 10, 'scale' => 2]])->save();
+      FieldConfig::create(['field_name' => 'field_decimal', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_decimal'])->save();
+      echo 'field_decimal created' . PHP_EOL;
+    "
 
-terminus drush "$SITE_ENV" -- ev "
-  use Drupal\field\Entity\FieldStorageConfig;
-  use Drupal\field\Entity\FieldConfig;
-  if (FieldStorageConfig::loadByName('node', 'field_list_text')) { echo 'field_list_text exists' . PHP_EOL; return; }
-  FieldStorageConfig::create(['field_name' => 'field_list_text', 'entity_type' => 'node', 'type' => 'list_string', 'settings' => ['allowed_values' => ['option1' => 'Option 1', 'option2' => 'Option 2', 'option3' => 'Option 3']]])->save();
-  FieldConfig::create(['field_name' => 'field_list_text', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_list_text'])->save();
-  echo 'field_list_text created' . PHP_EOL;
-"
+    terminus drush "$SITE_ENV" -- ev "
+      use Drupal\field\Entity\FieldStorageConfig;
+      use Drupal\field\Entity\FieldConfig;
+      if (FieldStorageConfig::loadByName('node', 'field_date')) { echo 'field_date exists' . PHP_EOL; return; }
+      FieldStorageConfig::create(['field_name' => 'field_date', 'entity_type' => 'node', 'type' => 'datetime', 'settings' => ['datetime_type' => 'date']])->save();
+      FieldConfig::create(['field_name' => 'field_date', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_date'])->save();
+      echo 'field_date created' . PHP_EOL;
+    "
 
-# ---------------------------------------------------------------------------
-# Step 4: Create test node with known field values
-# ---------------------------------------------------------------------------
-echo "[4/6] Creating test node..."
+    terminus drush "$SITE_ENV" -- ev "
+      use Drupal\field\Entity\FieldStorageConfig;
+      use Drupal\field\Entity\FieldConfig;
+      if (FieldStorageConfig::loadByName('node', 'field_datetime')) { echo 'field_datetime exists' . PHP_EOL; return; }
+      FieldStorageConfig::create(['field_name' => 'field_datetime', 'entity_type' => 'node', 'type' => 'datetime', 'settings' => ['datetime_type' => 'datetime']])->save();
+      FieldConfig::create(['field_name' => 'field_datetime', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_datetime'])->save();
+      echo 'field_datetime created' . PHP_EOL;
+    "
 
-terminus drush "$SITE_ENV" -- ev "
-  use Drupal\node\Entity\Node;
-  \$existing = \Drupal::entityQuery('node')
-    ->condition('type', 'field_test')
-    ->condition('title', 'Field Mapping Test Node')
-    ->accessCheck(FALSE)
-    ->count()
-    ->execute();
-  if (\$existing > 0) { echo 'Test node already exists' . PHP_EOL; return; }
-  \$node = Node::create([
-    'type' => 'field_test',
-    'title' => 'Field Mapping Test Node',
-    'field_text_plain' => 'Plain text value',
-    'field_text_long' => 'Long text with special chars: <>&',
-    'field_integer' => 42,
-    'field_decimal' => '3.14',
-    'field_boolean' => TRUE,
-    'field_date' => '2026-01-22',
-    'field_datetime' => '2026-01-22T10:30:00',
-    'field_list_text' => 'option2',
-    'field_email' => 'test@example.com',
-    'field_link' => ['uri' => 'https://example.com', 'title' => 'Example'],
-  ]);
-  \$node->save();
-  echo 'Node ' . \$node->id() . ' created' . PHP_EOL;
-"
+    terminus drush "$SITE_ENV" -- ev "
+      use Drupal\field\Entity\FieldStorageConfig;
+      use Drupal\field\Entity\FieldConfig;
+      if (FieldStorageConfig::loadByName('node', 'field_list_text')) { echo 'field_list_text exists' . PHP_EOL; return; }
+      FieldStorageConfig::create(['field_name' => 'field_list_text', 'entity_type' => 'node', 'type' => 'list_string', 'settings' => ['allowed_values' => ['option1' => 'Option 1', 'option2' => 'Option 2', 'option3' => 'Option 3']]])->save();
+      FieldConfig::create(['field_name' => 'field_list_text', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_list_text'])->save();
+      echo 'field_list_text created' . PHP_EOL;
+    "
 
-# ---------------------------------------------------------------------------
-# Step 5: Verify setup
-# ---------------------------------------------------------------------------
-echo "[5/6] Verifying setup..."
+    # Create test node
+    terminus drush "$SITE_ENV" -- ev "
+      use Drupal\node\Entity\Node;
+      \$existing = \Drupal::entityQuery('node')
+        ->condition('type', 'field_test')
+        ->condition('title', 'Field Mapping Test Node')
+        ->accessCheck(FALSE)
+        ->count()
+        ->execute();
+      if (\$existing > 0) { echo 'Test node already exists' . PHP_EOL; return; }
+      \$node = Node::create([
+        'type' => 'field_test',
+        'title' => 'Field Mapping Test Node',
+        'field_text_plain' => 'Plain text value',
+        'field_text_long' => 'Long text with special chars: <>&',
+        'field_integer' => 42,
+        'field_decimal' => '3.14',
+        'field_boolean' => TRUE,
+        'field_date' => '2026-01-22',
+        'field_datetime' => '2026-01-22T10:30:00',
+        'field_list_text' => 'option2',
+        'field_email' => 'test@example.com',
+        'field_link' => ['uri' => 'https://example.com', 'title' => 'Example'],
+      ]);
+      \$node->save();
+      echo 'Node ' . \$node->id() . ' created' . PHP_EOL;
+    "
 
-terminus drush "$SITE_ENV" -- ev "
-  \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');
-  if (!\$type) { echo 'FAIL: field_test content type missing' . PHP_EOL; exit(1); }
-  echo 'field_test content type: OK' . PHP_EOL;
+    # -----------------------------------------------------------------------
+    # Step 7: Verify setup
+    # -----------------------------------------------------------------------
+    echo "[7/7] Verifying setup..."
 
-  \$fields = [
-    'field_text_plain' => 'string',
-    'field_text_long' => 'text_long',
-    'field_integer' => 'integer',
-    'field_boolean' => 'boolean',
-    'field_email' => 'email',
-    'field_link' => 'link',
-    'field_decimal' => 'decimal',
-    'field_date' => 'datetime',
-    'field_datetime' => 'datetime',
-    'field_list_text' => 'list_string',
-  ];
-  foreach (\$fields as \$name => \$expected_type) {
-    \$storage = \Drupal\field\Entity\FieldStorageConfig::loadByName('node', \$name);
-    if (!\$storage) { echo 'FAIL: ' . \$name . ' missing' . PHP_EOL; exit(1); }
-    if (\$storage->getType() !== \$expected_type) { echo 'FAIL: ' . \$name . ' type is ' . \$storage->getType() . ', expected ' . \$expected_type . PHP_EOL; exit(1); }
-    echo \$name . ': OK (' . \$expected_type . ')' . PHP_EOL;
-  }
+    terminus drush "$SITE_ENV" -- ev "
+      \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');
+      if (!\$type) { echo 'FAIL: field_test content type missing' . PHP_EOL; exit(1); }
+      echo 'field_test content type: OK' . PHP_EOL;
 
-  \$query = \Drupal::entityQuery('node')
-    ->condition('type', 'field_test')
-    ->condition('title', 'Field Mapping Test Node')
-    ->accessCheck(FALSE)
-    ->count();
-  \$count = \$query->execute();
-  if (\$count == 0) { echo 'FAIL: test node missing' . PHP_EOL; exit(1); }
-  echo 'Test node: OK (' . \$count . ' found)' . PHP_EOL;
-"
+      \$fields = [
+        'field_text_plain' => 'string',
+        'field_text_long' => 'text_long',
+        'field_integer' => 'integer',
+        'field_boolean' => 'boolean',
+        'field_email' => 'email',
+        'field_link' => 'link',
+        'field_decimal' => 'decimal',
+        'field_date' => 'datetime',
+        'field_datetime' => 'datetime',
+        'field_list_text' => 'list_string',
+      ];
+      foreach (\$fields as \$name => \$expected_type) {
+        \$storage = \Drupal\field\Entity\FieldStorageConfig::loadByName('node', \$name);
+        if (!\$storage) { echo 'FAIL: ' . \$name . ' missing' . PHP_EOL; exit(1); }
+        if (\$storage->getType() !== \$expected_type) { echo 'FAIL: ' . \$name . ' type is ' . \$storage->getType() . ', expected ' . \$expected_type . PHP_EOL; exit(1); }
+        echo \$name . ': OK (' . \$expected_type . ')' . PHP_EOL;
+      }
 
-echo ""
-echo "=== Bootstrap complete ==="
-echo "Site: ${SITE_NAME}"
-echo "Dev URL: https://dev-${SITE_NAME}.pantheonsite.io"
-echo ""
-echo "pantheon.yml:"
-terminus drush "$SITE_ENV" -- ev "echo file_get_contents('/code/pantheon.yml');"
-echo ""
-echo "CI multidevs will inherit field_test content type, fields, and test node from dev."
-echo "Modules (search_api_pantheon, devel_generate) are installed per-multidev by create-multidev.sh."
+      \$query = \Drupal::entityQuery('node')
+        ->condition('type', 'field_test')
+        ->condition('title', 'Field Mapping Test Node')
+        ->accessCheck(FALSE)
+        ->count();
+      \$count = \$query->execute();
+      if (\$count == 0) { echo 'FAIL: test node missing' . PHP_EOL; exit(1); }
+      echo 'Test node: OK (' . \$count . ' found)' . PHP_EOL;
+    "
+
+    echo ""
+    echo "=== Bootstrap complete ==="
+    echo "Site: ${SITE_NAME_LC}"
+    echo "Site ID: ${SITE_ID}"
+    echo "Dev URL: https://dev-${SITE_NAME_LC}.pantheonsite.io"
+    echo ""
+    echo "CI multidevs will inherit field_test content type, fields, and test node from dev."
+    echo "Modules (search_api_pantheon, devel_generate) are installed per-multidev by create-multidev.sh."
+}
+
+main "$@"

--- a/.github/scripts/bootstrap-fixture-site.sh
+++ b/.github/scripts/bootstrap-fixture-site.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+set -euo pipefail
+
+# Bootstrap a Search API Pantheon CI fixture site from scratch.
+#
+# Recreates the full dev environment that CI multidev tests depend on.
+# Run this if a fixture site is destroyed, corrupted, or needs to be
+# rebuilt from zero. All steps are idempotent (safe to re-run).
+#
+# What it sets up:
+#   1. Pantheon site on drupal-composer-managed upstream (CI Fixtures org)
+#   2. pantheon.yml with Solr 8 and PHP version (8.1 for D10, 8.3 for D11)
+#   3. field_test content type with 10 fields (string, text_long, integer,
+#      boolean, email, link, decimal, datetime/date, datetime/datetime, list_string)
+#   4. "Field Mapping Test Node" with known values for all 10 fields
+#   5. Verification that everything was created correctly
+#
+# How to use:
+#   1. Authenticate terminus:
+#        terminus auth:login --machine-token=<token>
+#   2. Load your SSH key:
+#        ssh-add ~/.ssh/id_rsa
+#   3. Set git identity:
+#        git config --global user.email "you@example.com"
+#        git config --global user.name "Your Name"
+#   4. Run the script from the repo root:
+#        .github/scripts/bootstrap-fixture-site.sh search-api-pantheon-d10 10
+#        .github/scripts/bootstrap-fixture-site.sh search-api-pantheon-d11 11
+#   5. Verify the dev site at:
+#        https://dev-<site-name>.pantheonsite.io
+#
+# Arguments:
+#   $1  site-name       Pantheon site machine name (e.g. search-api-pantheon-d10)
+#   $2  drupal-version  Drupal major version: 10 or 11
+#   $3  org-uuid        (optional) Pantheon org UUID. Defaults to CI Fixtures org.
+#
+# Examples:
+#   .github/scripts/bootstrap-fixture-site.sh search-api-pantheon-d10 10
+#   .github/scripts/bootstrap-fixture-site.sh search-api-pantheon-d11 11
+#   .github/scripts/bootstrap-fixture-site.sh search-api-pantheon-d10 10 5ae1fa30-8cc4-4894-8ca9-d50628dcba17
+
+SITE_NAME="${1:?Usage: $0 <site-name> <drupal-version> [org-uuid]}"
+DRUPAL_VERSION="${2:?Usage: $0 <site-name> <drupal-version> [org-uuid]}"
+ORG="${3:-5ae1fa30-8cc4-4894-8ca9-d50628dcba17}"  # CI Fixtures for Projects
+
+UPSTREAM="drupal-composer-managed"
+SITE_ENV="${SITE_NAME}.dev"
+
+echo "=== Bootstrap CI Fixture Site ==="
+echo "Site: ${SITE_NAME}"
+echo "Drupal: ${DRUPAL_VERSION}"
+echo "Org: ${ORG}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 1: Create site (skip if exists)
+# ---------------------------------------------------------------------------
+if terminus site:info "$SITE_NAME" &>/dev/null; then
+  echo "[skip] Site ${SITE_NAME} already exists"
+else
+  echo "[1/5] Creating site..."
+  terminus site:create "$SITE_NAME" "$SITE_NAME" "$UPSTREAM" --org="$ORG"
+  echo "Waiting for site creation workflow..."
+  terminus workflow:wait "$SITE_ENV" --max=300
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Configure pantheon.yml (Solr 8, PHP version)
+# ---------------------------------------------------------------------------
+echo "[2/5] Configuring pantheon.yml..."
+
+GIT_URL=$(terminus connection:info "$SITE_ENV" --field=git_url)
+WORK_DIR=$(mktemp -d)
+GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone "$GIT_URL" "$WORK_DIR/site"
+cd "$WORK_DIR/site"
+
+if [ "$DRUPAL_VERSION" = "10" ]; then
+  PHP_VER="8.1"
+elif [ "$DRUPAL_VERSION" = "11" ]; then
+  PHP_VER="8.3"
+else
+  PHP_VER="8.3"
+fi
+
+if [ -f pantheon.yml ]; then
+  if ! grep -q "^search:" pantheon.yml; then
+    echo "search:" >> pantheon.yml
+    echo "  version: 8" >> pantheon.yml
+  fi
+  if ! grep -q "php_version:" pantheon.yml; then
+    echo "php_version: ${PHP_VER}" >> pantheon.yml
+  fi
+else
+  cat > pantheon.yml <<YAML
+api_version: 1
+php_version: ${PHP_VER}
+search:
+  version: 8
+YAML
+fi
+
+if git diff --quiet pantheon.yml; then
+  echo "[skip] pantheon.yml already configured"
+else
+  git add pantheon.yml
+  git commit -m "Configure Solr 8 and PHP ${PHP_VER} for CI fixture"
+  git push origin master
+  terminus workflow:wait "$SITE_ENV" --max=300
+fi
+
+cd /tmp
+rm -rf "$WORK_DIR"
+
+# Wait for environment to be ready after code push
+echo "Waiting for Drupal to be available..."
+for i in $(seq 1 12); do
+  if terminus drush "$SITE_ENV" -- status --field=bootstrap 2>/dev/null | grep -q "Successful"; then
+    echo "Drupal ready"
+    break
+  fi
+  if [ "$i" -eq 12 ]; then
+    echo "ERROR: Drupal not ready after 2 minutes"
+    exit 1
+  fi
+  sleep 10
+done
+
+# ---------------------------------------------------------------------------
+# Step 3: Create field_test content type and 10 fields
+# ---------------------------------------------------------------------------
+echo "[3/5] Creating field_test content type and fields..."
+
+terminus drush "$SITE_ENV" -- ev "
+  \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');
+  if (\$type) { echo 'field_test already exists, skipping' . PHP_EOL; return; }
+  \$type = \Drupal::entityTypeManager()->getStorage('node_type')->create([
+    'type' => 'field_test',
+    'name' => 'Field Test',
+  ]);
+  \$type->save();
+  echo 'Content type created' . PHP_EOL;
+"
+
+# Simple fields (no custom settings)
+SIMPLE_FIELDS="field_text_plain:string field_text_long:text_long field_integer:integer field_boolean:boolean field_email:email field_link:link"
+
+for FIELD_DEF in $SIMPLE_FIELDS; do
+  FIELD_NAME="${FIELD_DEF%%:*}"
+  FIELD_TYPE="${FIELD_DEF##*:}"
+  terminus drush "$SITE_ENV" -- ev "
+    use Drupal\field\Entity\FieldStorageConfig;
+    use Drupal\field\Entity\FieldConfig;
+    if (FieldStorageConfig::loadByName('node', '${FIELD_NAME}')) { echo '${FIELD_NAME} exists' . PHP_EOL; return; }
+    FieldStorageConfig::create(['field_name' => '${FIELD_NAME}', 'entity_type' => 'node', 'type' => '${FIELD_TYPE}'])->save();
+    FieldConfig::create(['field_name' => '${FIELD_NAME}', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => '${FIELD_NAME}'])->save();
+    echo '${FIELD_NAME} created' . PHP_EOL;
+  "
+done
+
+# Fields with custom settings
+terminus drush "$SITE_ENV" -- ev "
+  use Drupal\field\Entity\FieldStorageConfig;
+  use Drupal\field\Entity\FieldConfig;
+  if (FieldStorageConfig::loadByName('node', 'field_decimal')) { echo 'field_decimal exists' . PHP_EOL; return; }
+  FieldStorageConfig::create(['field_name' => 'field_decimal', 'entity_type' => 'node', 'type' => 'decimal', 'settings' => ['precision' => 10, 'scale' => 2]])->save();
+  FieldConfig::create(['field_name' => 'field_decimal', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_decimal'])->save();
+  echo 'field_decimal created' . PHP_EOL;
+"
+
+terminus drush "$SITE_ENV" -- ev "
+  use Drupal\field\Entity\FieldStorageConfig;
+  use Drupal\field\Entity\FieldConfig;
+  if (FieldStorageConfig::loadByName('node', 'field_date')) { echo 'field_date exists' . PHP_EOL; return; }
+  FieldStorageConfig::create(['field_name' => 'field_date', 'entity_type' => 'node', 'type' => 'datetime', 'settings' => ['datetime_type' => 'date']])->save();
+  FieldConfig::create(['field_name' => 'field_date', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_date'])->save();
+  echo 'field_date created' . PHP_EOL;
+"
+
+terminus drush "$SITE_ENV" -- ev "
+  use Drupal\field\Entity\FieldStorageConfig;
+  use Drupal\field\Entity\FieldConfig;
+  if (FieldStorageConfig::loadByName('node', 'field_datetime')) { echo 'field_datetime exists' . PHP_EOL; return; }
+  FieldStorageConfig::create(['field_name' => 'field_datetime', 'entity_type' => 'node', 'type' => 'datetime', 'settings' => ['datetime_type' => 'datetime']])->save();
+  FieldConfig::create(['field_name' => 'field_datetime', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_datetime'])->save();
+  echo 'field_datetime created' . PHP_EOL;
+"
+
+terminus drush "$SITE_ENV" -- ev "
+  use Drupal\field\Entity\FieldStorageConfig;
+  use Drupal\field\Entity\FieldConfig;
+  if (FieldStorageConfig::loadByName('node', 'field_list_text')) { echo 'field_list_text exists' . PHP_EOL; return; }
+  FieldStorageConfig::create(['field_name' => 'field_list_text', 'entity_type' => 'node', 'type' => 'list_string', 'settings' => ['allowed_values' => ['option1' => 'Option 1', 'option2' => 'Option 2', 'option3' => 'Option 3']]])->save();
+  FieldConfig::create(['field_name' => 'field_list_text', 'entity_type' => 'node', 'bundle' => 'field_test', 'label' => 'field_list_text'])->save();
+  echo 'field_list_text created' . PHP_EOL;
+"
+
+# ---------------------------------------------------------------------------
+# Step 4: Create test node with known field values
+# ---------------------------------------------------------------------------
+echo "[4/5] Creating test node..."
+
+terminus drush "$SITE_ENV" -- ev "
+  use Drupal\node\Entity\Node;
+  \$existing = \Drupal::entityQuery('node')
+    ->condition('type', 'field_test')
+    ->condition('title', 'Field Mapping Test Node')
+    ->accessCheck(FALSE)
+    ->count()
+    ->execute();
+  if (\$existing > 0) { echo 'Test node already exists' . PHP_EOL; return; }
+  \$node = Node::create([
+    'type' => 'field_test',
+    'title' => 'Field Mapping Test Node',
+    'field_text_plain' => 'Plain text value',
+    'field_text_long' => 'Long text with special chars: <>&',
+    'field_integer' => 42,
+    'field_decimal' => '3.14',
+    'field_boolean' => TRUE,
+    'field_date' => '2026-01-22',
+    'field_datetime' => '2026-01-22T10:30:00',
+    'field_list_text' => 'option2',
+    'field_email' => 'test@example.com',
+    'field_link' => ['uri' => 'https://example.com', 'title' => 'Example'],
+  ]);
+  \$node->save();
+  echo 'Node ' . \$node->id() . ' created' . PHP_EOL;
+"
+
+# ---------------------------------------------------------------------------
+# Step 5: Verify setup
+# ---------------------------------------------------------------------------
+echo "[5/5] Verifying setup..."
+
+terminus drush "$SITE_ENV" -- ev "
+  \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');
+  if (!\$type) { echo 'FAIL: field_test content type missing' . PHP_EOL; exit(1); }
+  echo 'field_test content type: OK' . PHP_EOL;
+
+  \$fields = [
+    'field_text_plain' => 'string',
+    'field_text_long' => 'text_long',
+    'field_integer' => 'integer',
+    'field_boolean' => 'boolean',
+    'field_email' => 'email',
+    'field_link' => 'link',
+    'field_decimal' => 'decimal',
+    'field_date' => 'datetime',
+    'field_datetime' => 'datetime',
+    'field_list_text' => 'list_string',
+  ];
+  foreach (\$fields as \$name => \$expected_type) {
+    \$storage = \Drupal\field\Entity\FieldStorageConfig::loadByName('node', \$name);
+    if (!\$storage) { echo 'FAIL: ' . \$name . ' missing' . PHP_EOL; exit(1); }
+    if (\$storage->getType() !== \$expected_type) { echo 'FAIL: ' . \$name . ' type is ' . \$storage->getType() . ', expected ' . \$expected_type . PHP_EOL; exit(1); }
+    echo \$name . ': OK (' . \$expected_type . ')' . PHP_EOL;
+  }
+
+  \$query = \Drupal::entityQuery('node')
+    ->condition('type', 'field_test')
+    ->condition('title', 'Field Mapping Test Node')
+    ->accessCheck(FALSE)
+    ->count();
+  \$count = \$query->execute();
+  if (\$count == 0) { echo 'FAIL: test node missing' . PHP_EOL; exit(1); }
+  echo 'Test node: OK (' . \$count . ' found)' . PHP_EOL;
+"
+
+echo ""
+echo "=== Bootstrap complete ==="
+echo "Site: ${SITE_NAME}"
+echo "Dev URL: https://dev-${SITE_NAME}.pantheonsite.io"
+echo ""
+echo "pantheon.yml:"
+terminus drush "$SITE_ENV" -- ev "echo file_get_contents('/code/pantheon.yml');"
+echo ""
+echo "CI multidevs will inherit field_test content type, fields, and test node from dev."
+echo "Modules (search_api_pantheon, devel_generate) are installed per-multidev by create-multidev.sh."

--- a/.github/scripts/bootstrap-fixture-site.sh
+++ b/.github/scripts/bootstrap-fixture-site.sh
@@ -10,10 +10,12 @@ set -eou pipefail
 # What it sets up:
 #   1. Pantheon site on correct upstream + Drupal install
 #   2. Performance Small plan + Solr enabled
-#   3. pantheon.yml with Solr 8 and PHP version
-#   4. field_test content type with 10 fields
-#   5. "Field Mapping Test Node" with known values
-#   6. Verification
+#   3. field_test content type with 10 fields
+#   4. "Field Mapping Test Node" with known values
+#   5. Verification
+#
+# Note: pantheon.yml (search version, php_version) must be configured
+# manually via git push after running this script.
 #
 # Examples:
 #   .github/scripts/bootstrap-fixture-site.sh -n search-api-pantheon-d10 -u d10
@@ -97,7 +99,7 @@ main() {
         exit 1
     fi
 
-    echo "[1/6] Creating site..."
+    echo "[1/5] Creating site..."
     terminus site:create "$SITE_NAME" "$SITE_NAME" "$UPSTREAM" --org="$ORG"
     echo "Waiting for site creation workflow..."
     terminus workflow:wait "$SITE_ENV"
@@ -108,7 +110,7 @@ main() {
     # -----------------------------------------------------------------------
     # Step 2: Install Drupal
     # -----------------------------------------------------------------------
-    echo "[2/6] Installing Drupal..."
+    echo "[2/5] Installing Drupal..."
     if terminus drush "$SITE_ENV" -- status --field=bootstrap 2>/dev/null | grep -q "Successful"; then
         echo "[skip] Drupal already installed"
     else
@@ -118,7 +120,7 @@ main() {
     # -----------------------------------------------------------------------
     # Step 3: Upgrade plan + enable Solr
     # -----------------------------------------------------------------------
-    echo "[3/6] Configuring plan and Solr..."
+    echo "[3/5] Configuring plan and Solr..."
     local CURRENT_PLAN
     CURRENT_PLAN=$(terminus site:info "$SITE_NAME_LC" --field=plan_name 2>/dev/null || echo "")
     if [[ "$CURRENT_PLAN" == *"Sandbox"* ]]; then
@@ -130,76 +132,6 @@ main() {
 
     echo "Enabling Solr..."
     terminus solr:enable "$SITE_ID" 2>/dev/null || echo "[skip] Solr already enabled or enable failed"
-
-    # -----------------------------------------------------------------------
-    # Step 4: Configure pantheon.yml (Solr 8, PHP version)
-    # -----------------------------------------------------------------------
-    echo "[4/6] Configuring pantheon.yml..."
-
-    local GIT_URL
-    GIT_URL=$(terminus connection:info "$SITE_ENV" --field=git_url)
-    local WORK_DIR
-    WORK_DIR=$(mktemp -d)
-    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone "$GIT_URL" "$WORK_DIR/site"
-
-    pushd "$WORK_DIR/site" > /dev/null
-
-    echo "Current pantheon.yml:"
-    if [ -f pantheon.yml ]; then
-        cat pantheon.yml
-    else
-        echo "(file does not exist)"
-    fi
-    echo "---"
-
-    if [ -f pantheon.yml ]; then
-        if ! grep -q "^search:" pantheon.yml; then
-            echo "Adding search config..."
-            echo "search:" >> pantheon.yml
-            echo "  version: 8" >> pantheon.yml
-        else
-            echo "search: already present"
-        fi
-        if ! grep -q "php_version:" pantheon.yml; then
-            echo "Adding php_version: ${PHP_VER}..."
-            echo "php_version: ${PHP_VER}" >> pantheon.yml
-        else
-            echo "php_version: already present ($(grep php_version pantheon.yml))"
-        fi
-    else
-        echo "Creating pantheon.yml from scratch..."
-        cat > pantheon.yml <<YAML
-api_version: 1
-php_version: ${PHP_VER}
-search:
-  version: 8
-YAML
-    fi
-
-    echo "Updated pantheon.yml:"
-    cat pantheon.yml
-    echo "---"
-
-    if git diff --quiet pantheon.yml 2>/dev/null; then
-        echo "[skip] No changes to pantheon.yml"
-    else
-        echo "Changes detected:"
-        git diff pantheon.yml
-        git add pantheon.yml
-        git commit -m "Configure Solr 8 and PHP ${PHP_VER} for CI fixture"
-        git push origin master
-        terminus workflow:wait "$SITE_ENV"
-    fi
-
-    popd > /dev/null
-    rm -rf "$WORK_DIR"
-
-    # Ensure connection mode is git
-    local CONNECTION_TYPE
-    CONNECTION_TYPE=$(terminus env:info "$SITE_ENV" --field="Connection Mode" 2>/dev/null || echo "")
-    if [[ "$CONNECTION_TYPE" != "git" ]]; then
-        terminus connection:set "$SITE_ENV" git
-    fi
 
     # Wait for Drupal to be available
     echo "Waiting for Drupal to be available..."
@@ -218,7 +150,7 @@ YAML
     # -----------------------------------------------------------------------
     # Step 5: Create field_test content type, fields, and test node
     # -----------------------------------------------------------------------
-    echo "[5/6] Creating field_test content type, fields, and test node..."
+    echo "[4/5] Creating field_test content type, fields, and test node..."
 
     terminus drush "$SITE_ENV" -- ev "
       \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');
@@ -315,7 +247,7 @@ YAML
     # -----------------------------------------------------------------------
     # Step 7: Verify setup
     # -----------------------------------------------------------------------
-    echo "[6/6] Verifying setup..."
+    echo "[5/5] Verifying setup..."
 
     terminus drush "$SITE_ENV" -- ev "
       \$type = \Drupal::entityTypeManager()->getStorage('node_type')->load('field_test');


### PR DESCRIPTION
## Summary

- Add `.github/scripts/bootstrap-fixture-site.sh` for recreating CI fixture sites from scratch

## Context

CI tests rely on pre-baked content (field_test content type, 10 fields, test node) on the dev environments of `search-api-pantheon-d10` and `search-api-pantheon-d11`. If these sites are ever destroyed, there was no documented way to recreate the setup. This script automates the full bootstrap.

## How to use

1. Authenticate terminus:
   ```bash
   terminus auth:login --machine-token=<token>
   ```

2. Load SSH key:
   ```bash
   ssh-add ~/.ssh/id_rsa
   ```

3. Set git identity:
   ```bash
   git config --global user.email "you@example.com"
   git config --global user.name "Your Name"
   ```

4. Run from repo root:
   ```bash
   # D10 fixture site
   .github/scripts/bootstrap-fixture-site.sh -n search-api-pantheon-d10 -u d10

   # D11 fixture site
   .github/scripts/bootstrap-fixture-site.sh -n search-api-pantheon-d11 -u d11
   ```

5. Verify dev site at `https://dev-<site-name>.pantheonsite.io`

All steps are idempotent. Safe to re-run on existing sites.

## What the script does

1. Creates Pantheon site on the version-pinned upstream (`drupal-10-composer-managed` for D10, `drupal-11-composer-managed` for D11) in the CI Fixtures org (skips if exists)
2. Installs Drupal, sets Performance Small plan, enables the Solr add-on
3. Creates `field_test` content type with 10 fields: string, text_long, integer, boolean, email, link, decimal, datetime/date, datetime/datetime, list_string (with allowed_values option1/2/3)
4. Creates "Field Mapping Test Node" with known values matching what `test-field-mapping.sh` expects
5. Verifies all content type, field types, and test node exist

`pantheon.yml` (Solr `version`, `php_version`) is **not** written here. Those are per-multidev values set by `create-multidev.sh` from the CI matrix at test time. The bootstrap builds only the shared base content on dev. Modules (search_api_pantheon, devel) are also installed per-multidev by `create-multidev.sh`.

## Test plan

- [x] Validated field values match current D10 and D11 dev environments
- [x] Bootstrap run end-to-end on a throwaway D10 site; base matched live `search-api-pantheon-d10` byte-for-byte; module enable + Solr server verified AVAILABLE
- [x] Reviewed script logic against `test-field-mapping.sh` expectations (zero mismatches)
