### PR TITLE
feat(schema-poster): [SITE-5775] retry postSchema on transient Solr errors

### DIFF
--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -32,26 +32,16 @@ echo "::endgroup::"
 
 # Post the Solr schema config set. Must happen before content generation,
 # otherwise Solr may be busy indexing with the wrong schema.
-# Retries handle transient 502s from Solr endpoint availability.
+# The module retries transient 502s/timeouts internally (SITE-5775).
 echo "::group::Test schema post"
 SOLR_VER="${SOLR_VERSION:-8}"
 SCHEMA_PATH="/code/web/modules/contrib/search_api_solr/jump-start/solr${SOLR_VER}/config-set"
-MAX_RETRIES=3
-RETRY_DELAY=60
-for attempt in $(seq 1 $MAX_RETRIES); do
-  echo "Schema post attempt $attempt of $MAX_RETRIES"
-  if terminus drush "$SITE_ENV" -- search-api-pantheon:postSchema "$SCHEMA_PATH"; then
-    echo "::notice::Schema post completed (attempt $attempt)"
-    break
-  fi
-  if [ "$attempt" -eq "$MAX_RETRIES" ]; then
-    echo "::error::Schema post failed after $MAX_RETRIES attempts"
-    FAILED=1
-  else
-    echo "::warning::Schema post failed (attempt $attempt), retrying in ${RETRY_DELAY}s..."
-    sleep $RETRY_DELAY
-  fi
-done
+if terminus drush "$SITE_ENV" -- search-api-pantheon:postSchema "$SCHEMA_PATH"; then
+  echo "::notice::Schema post completed"
+else
+  echo "::error::Schema post failed"
+  FAILED=1
+fi
 echo "::endgroup::"
 
 # Count pre-existing content (inherited from dev environment)

--- a/.github/scripts/test-field-mapping.sh
+++ b/.github/scripts/test-field-mapping.sh
@@ -59,23 +59,14 @@ terminus drush "$SITE_ENV" -- ev "
 terminus drush "$SITE_ENV" -- config:set search_api.server.pantheon_search backend_config.connector_config.http_method POST -y
 echo "::endgroup::"
 
-# Post schema (retry on transient 502s)
+# Post schema. The module retries transient 502s/timeouts internally (SITE-5775).
 echo "::group::Post Solr schema"
-MAX_RETRIES=3
-RETRY_DELAY=60
-for attempt in $(seq 1 $MAX_RETRIES); do
-  echo "Schema post attempt $attempt of $MAX_RETRIES"
-  if terminus drush "$SITE_ENV" -- search-api-pantheon:postSchema; then
-    echo "::notice::Schema post completed (attempt $attempt)"
-    break
-  fi
-  if [ "$attempt" -eq "$MAX_RETRIES" ]; then
-    echo "::error::Schema post failed after $MAX_RETRIES attempts"
-    exit 1
-  fi
-  echo "::warning::Schema post failed (attempt $attempt), retrying in ${RETRY_DELAY}s..."
-  sleep $RETRY_DELAY
-done
+if terminus drush "$SITE_ENV" -- search-api-pantheon:postSchema; then
+  echo "::notice::Schema post completed"
+else
+  echo "::error::Schema post failed"
+  exit 1
+fi
 echo "::endgroup::"
 
 # Verify test node exists (inherited from dev environment) and index it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       DRUPAL_VERSION: ${{ matrix.drupal-version }}
       GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
       GITHUB_RUN_NUMBER: ${{ github.run_number }}
-      PANTHEON_CI_SSH_KEY: ${{ secrets.SANDBOX_SSH_KEY }}
+      PANTHEON_CI_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       PHP_VERSION: ${{ matrix.php-version }}
       SOLR_VERSION: ${{ matrix.solr-version }}
       TERMINUS_SITE: ${{ matrix.drupal-version == 10 && vars.PANTHEON_SITE_D10 || vars.PANTHEON_SITE_D11 }}

--- a/src/Plugin/SolrConnector/PantheonSolrConnector.php
+++ b/src/Plugin/SolrConnector/PantheonSolrConnector.php
@@ -145,7 +145,9 @@ class PantheonSolrConnector extends StandardSolrConnector {
    * @internal
    */
   public function postSchema(array $schemaFiles): Response {
-    $this->useTimeout();
+    // Schema uploads transfer multiple base64-encoded files, which can take
+    // longer than the default QUERY_TIMEOUT (5s). Use FINALIZE_TIMEOUT (30s).
+    $this->useTimeout(self::FINALIZE_TIMEOUT);
     $filesToSend = [];
     foreach ($schemaFiles as $filename => $file_contents) {
       $this->logger->info($this->t('Encoding file: {filename}'), [

--- a/src/Services/SchemaPoster.php
+++ b/src/Services/SchemaPoster.php
@@ -10,6 +10,7 @@ use Drupal\search_api\ServerInterface;
 use Drupal\search_api_pantheon\GetPantheonSolrServerTrait;
 use Drupal\search_api_pantheon\Plugin\SolrConnector\PantheonSolrConnector;
 use Drupal\search_api_solr\Controller\SolrConfigSetController;
+use Drupal\search_api_solr\SearchApiSolrException;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\ResponseInterface;
@@ -66,7 +67,7 @@ class SchemaPoster implements LoggerAwareInterface {
       if (!$files) {
         $files = $this->getSolrFiles($server);
       }
-      $response = $this->getPantheonSolrConnector($server)->postSchema($files);
+      $response = $this->postSchemaWithRetry($server, $files);
     }
     // LOCAL DOCKER.
     if (isset($_SERVER['ENV']) && $_SERVER['ENV'] === 'local') {
@@ -83,6 +84,69 @@ class SchemaPoster implements LoggerAwareInterface {
       $this->getPantheonSolrConnector($server)->reloadCore();
     }
     return $this->processResponse($response);
+  }
+
+  /**
+   * Post the schema to Solr, retrying on transient gateway/timeout errors.
+   *
+   * During Solr core provisioning or pod rescheduling the gateway can briefly
+   * return a 502/503 or the request can time out (curl error 28). A manual
+   * retry usually succeeds within seconds, so retry automatically with
+   * exponential backoff (1s, 2s, 4s) before giving up.
+   *
+   * @param \Drupal\search_api\ServerInterface $server
+   *   The server to post the schema to.
+   * @param array $files
+   *   Array of files to post.
+   *
+   * @return \Solarium\Core\Client\Response
+   *   The Solarium response object.
+   *
+   * @throws \Drupal\search_api_solr\SearchApiSolrException
+   */
+  protected function postSchemaWithRetry(ServerInterface $server, array $files): Response {
+    $max_retries = 3;
+    $retry_status_codes = [502, 503];
+    $attempt = 0;
+
+    while (TRUE) {
+      $attempt++;
+      try {
+        $response = $this->getPantheonSolrConnector($server)->postSchema($files);
+        $status_code = $response->getStatusCode();
+        // Some Solarium versions return a gateway error as a response object
+        // instead of throwing, so check the status code too.
+        if (in_array($status_code, $retry_status_codes, TRUE) && $attempt <= $max_retries) {
+          $delay = 2 ** ($attempt - 1);
+          $this->logger->warning('postSchema attempt {attempt} returned transient status {status}. Retrying in {delay}s.', [
+            'attempt' => $attempt,
+            'status' => $status_code,
+            'delay' => $delay,
+          ]);
+          sleep($delay);
+          continue;
+        }
+        return $response;
+      }
+      catch (SearchApiSolrException $e) {
+        // Transient failures surface as exceptions: code 502/503 for gateway
+        // errors, code 0 for curl timeouts / connection failures.
+        $code = $e->getCode();
+        $is_transient = $code === 0 || in_array($code, $retry_status_codes, TRUE);
+        if ($is_transient && $attempt <= $max_retries) {
+          $delay = 2 ** ($attempt - 1);
+          $this->logger->warning('postSchema attempt {attempt} failed with transient error (code {code}): {message}. Retrying in {delay}s.', [
+            'attempt' => $attempt,
+            'code' => $code,
+            'message' => $e->getMessage(),
+            'delay' => $delay,
+          ]);
+          sleep($delay);
+          continue;
+        }
+        throw $e;
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- Raise the `postSchema` request timeout from `QUERY_TIMEOUT` (5s) to `FINALIZE_TIMEOUT` (30s). Schema uploads transfer several base64-encoded files and can exceed the short query timeout.
- Add automatic retry with exponential backoff (1s, 2s, 4s, max 3 retries) for transient errors in `SchemaPoster::postSchema()`. Retries on 502/503 and curl timeouts (code 0), handling both the thrown-exception and returned-response forms. Non-transient errors fail immediately.

## Context

[SITE-5775](https://getpantheon.atlassian.net/browse/SITE-5775)

`drush search-api-pantheon:postSchema` intermittently fails with a 502/503 or curl timeout (error 28) in two scenarios:

- **Provisioning window**: after setting `search.version` in `pantheon.yml`, the Solr core is lazy-provisioned on the first search request. If `postSchema` is an early request, it can hit a 502 before provisioning completes.
- **Transient gateway errors**: on an already-provisioned core, the gateway can return 502 or time out due to pod rescheduling, core resurrection after 48h idle, or backend restarts.

Both produce the same symptoms. A manual retry succeeds within seconds, but users had no automatic recovery. A shell-level retry workaround already exists in the CI scripts; this moves the recovery into the module so customers benefit too.

## Implementation notes

- Retry lives in a new `postSchemaWithRetry()` helper; `postSchema()` itself changes by one line. Existing status handling, core reload, and response processing are untouched.
- Transient errors can surface either as a thrown `SearchApiSolrException` (code 502/503, or code 0 for curl timeouts) or, depending on the Solarium version, as a response object carrying the status code. The helper handles both.

## Test plan

- [ ] CI integration tests (schema post) pass across all 8 Drupal/PHP/Solr matrix combinations
- [ ] Manual: confirm `postSchema` still succeeds on a healthy core (happy path unchanged)

## References

- Jira: [SITE-5775](https://getpantheon.atlassian.net/browse/SITE-5775)

[SITE-5775]: https://getpantheon.atlassian.net/browse/SITE-5775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-5775]: https://getpantheon.atlassian.net/browse/SITE-5775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ