### PR TITLE
Prepare 8.5.0 GA release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
     name: Multidev test (Drupal ${{ matrix.drupal-version }}, PHP ${{ matrix.php-version }}, Solr ${{ matrix.solr-version }})
     needs: [linting, phpcompatibility]
     env:
+      COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
       DRUPAL_VERSION: ${{ matrix.drupal-version }}
       GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
       GITHUB_RUN_NUMBER: ${{ github.run_number }}

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,7 +13,7 @@ Search API Pantheon 8.5.0
 ### Improvements
 
 - Increased schema upload timeout to prevent failures on large config-sets
-- Added automatic retry on temporary server errors during schema uploads (up to 3 attempts)
+- Added automatic retry on temporary server errors during schema uploads
 
 See README.md for installation and UPGRADE.md for upgrade instructions:
 - https://git.drupalcode.org/project/search_api_pantheon/-/blob/8.5.x/README.md

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,24 @@
+Search API Pantheon 8.5.0
+--------------------------------------------------
+
+### What's New
+
+- Added support for Apache Solr 9 (9.10.1)
+- Added compatibility for PHP 8.5
+
+### Bug Fixes
+
+- Resolved SSL and Solr connection issues with Lando
+
+### Improvements
+
+- Increased schema upload timeout to prevent failures on large config-sets
+- Added automatic retry on temporary server errors during schema uploads (up to 3 attempts)
+
+See README.md for installation and UPGRADE.md for upgrade instructions:
+- https://git.drupalcode.org/project/search_api_pantheon/-/blob/8.5.x/README.md
+- https://git.drupalcode.org/project/search_api_pantheon/-/blob/8.5.x/UPGRADE.md
+
 Search API Pantheon 8.5.0-beta1
 --------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Search API Solr provides the ability to connect to any Solr server by providing 
 ### Solr Versions on Pantheon
 
 - Solr 8: [Apache Solr 8.11.4](https://solr.apache.org/docs/8_11_4/)
-- Solr 9: [Apache Solr 9.10.0](https://solr.apache.org/docs/9_10_0/)
+- Solr 9: [Apache Solr 9.10.1](https://solr.apache.org/docs/9_10_1/)
 
 ## Requirements
 
@@ -46,12 +46,6 @@ Search API Solr provides the ability to connect to any Solr server by providing 
 
 ```bash
 composer require 'drupal/search_api_pantheon:^8'
-```
-
-### Beta Release (Solr 9 Support)
-
-```bash
-composer require 'drupal/search_api_pantheon:^8.5@beta'
 ```
 
 ### Development Version

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,9 +2,6 @@
 
 ## Upgrading to 8.5.x
 
-> [!NOTE]
->**Beta Release: Version 8.5.x is currently in beta. Test thoroughly on non-production environments and report issues in [the drupal.org issue queue](https://www.drupal.org/project/issues/search_api_pantheon?categories=All).**
-
 Version 8.5.x adds support for Apache Solr 9. Existing Solr 8 installations continue to work without changes.
 
 ### Upgrading from 8.4.x to 8.5.x
@@ -14,7 +11,7 @@ Version 8.5.x requires [Search API Solr](https://www.drupal.org/project/search_a
 1. **Update the module** and commit and deploy the changes to your Pantheon environment:
 
    ```bash
-   composer require 'drupal/search_api_pantheon:^8.5@beta'
+   composer require 'drupal/search_api_pantheon:^8.5'
    git add composer.json composer.lock
    git commit -m "Update search_api_pantheon to 8.5.x"
    git push
@@ -38,7 +35,7 @@ If you are upgrading from an existing Solr 8 installation, upgrade the module fi
 1. If you are not on Search API Pantheon 8.5.x, update the module to 8.5.x and commit and deploy the changes to your Pantheon environment:
 
    ```bash
-   composer require 'drupal/search_api_pantheon:^8.5@beta'
+   composer require 'drupal/search_api_pantheon:^8.5'
    git add composer.json composer.lock
    git commit -m "Update search_api_pantheon to 8.5.x"
    git push


### PR DESCRIPTION
> **Note:**  This PR will be merged on June 29, 2026.

## Summary
- Remove beta language from README.md and UPGRADE.md
- Update Solr 9 version from 9.10.0 to 9.10.1
- Add changelog entry for 8.5.0 GA release

