### PR TITLE
ci: [SITE-5464] bypass GitHub API in multidev composer install to avoid 429

### DIFF
--- a/.github/scripts/cleanup-multidevs.sh
+++ b/.github/scripts/cleanup-multidevs.sh
@@ -10,7 +10,7 @@ CURRENT_ENV="${2:-}" # e.g. "d10p81s8-25" (skip this one, it's the current run)
 MAX_AGE_HOURS=72
 
 # Matches CI-generated multidev names like d10p81s8-25, d11p83s9-31
-CI_PATTERN='^d[0-9]+p[0-9]+s[0-9]+-[0-9]+'
+CI_PATTERN='^(d[0-9]+p[0-9]+s[0-9]+|[0-9]+s[0-9]+)-[0-9]+'
 
 if [[ -z "$TERMINUS_SITE" || -z "$PREFIX" ]]; then
   echo "::error::TERMINUS_SITE and PREFIX (arg 1) must be set."

--- a/.github/scripts/create-multidev.sh
+++ b/.github/scripts/create-multidev.sh
@@ -36,6 +36,14 @@ cd pantheon-site
 echo "Checking out branch $MULTIDEV..."
 git checkout "$MULTIDEV"
 
+# Authenticate Composer to the GitHub API so VCS metadata requests use the
+# authenticated rate limit (5000/hr) instead of the anonymous one (60/hr),
+# which returns HTTP 429 on busy matrix runs. GH_TOKEN is the run's built-in
+# GITHUB_TOKEN (contents: read on this repo is sufficient; no PAT needed).
+if [ -n "${GH_TOKEN:-}" ]; then
+  composer config --global --auth github-oauth.github.com "$GH_TOKEN"
+fi
+
 # Add module via VCS repo so we can install branch builds (not just tagged releases).
 # devel provides the genc (generate content) command used by run-tests.sh.
 composer config repositories.search_api_pantheon '{"type": "vcs", "url": "git@github.com:pantheon-systems/search_api_pantheon.git", "canonical": false}'

--- a/.github/scripts/create-multidev.sh
+++ b/.github/scripts/create-multidev.sh
@@ -113,7 +113,7 @@ echo "MULTIDEV_ENV=$MULTIDEV" >> "$GITHUB_ENV_FILE"
 
 # Create a second bare multidev for parity testing.
 # Replace the last char of the truncated name to stay within the 11-char limit.
-# e.g. d10p81s8-25 -> d10p81s8-2b
+# e.g. 1081s8-2630 -> 1081s8-263b
 PARITY_ENV="${MULTIDEV:0:10}b"
 echo "Creating parity multidev: $PARITY_ENV"
 if terminus multidev:list "$TERMINUS_SITE" --format=list | grep -q "^$PARITY_ENV$"; then

--- a/.github/scripts/create-multidev.sh
+++ b/.github/scripts/create-multidev.sh
@@ -36,17 +36,11 @@ cd pantheon-site
 echo "Checking out branch $MULTIDEV..."
 git checkout "$MULTIDEV"
 
-# Authenticate Composer to the GitHub API so VCS metadata requests use the
-# authenticated rate limit (5000/hr) instead of the anonymous one (60/hr),
-# which returns HTTP 429 on busy matrix runs. GH_TOKEN is the run's built-in
-# GITHUB_TOKEN (contents: read on this repo is sufficient; no PAT needed).
-if [ -n "${GH_TOKEN:-}" ]; then
-  composer config --global --auth github-oauth.github.com "$GH_TOKEN"
-fi
-
 # Add module via VCS repo so we can install branch builds (not just tagged releases).
+# no-api: clone over git instead of querying api.github.com, which rate-limits
+# (HTTP 429) the busy matrix. Public repo over https needs no auth.
 # devel provides the genc (generate content) command used by run-tests.sh.
-composer config repositories.search_api_pantheon '{"type": "vcs", "url": "git@github.com:pantheon-systems/search_api_pantheon.git", "canonical": false}'
+composer config repositories.search_api_pantheon '{"type": "vcs", "url": "https://github.com/pantheon-systems/search_api_pantheon.git", "no-api": true, "canonical": false}'
 composer require "pantheon-systems/search_api_pantheon:${GIT_REF}" drupal/devel:~5.4
 
 echo "Module installed at:"

--- a/.github/scripts/set-multidev-and-constraint.sh
+++ b/.github/scripts/set-multidev-and-constraint.sh
@@ -11,12 +11,12 @@ if [[ -z "$DRUPAL_VERSION" || -z "$PHP_VERSION" || -z "$GITHUB_RUN_NUMBER" ]]; t
   exit 1
 fi
 
-# Multidev name: d{drupal}p{php}s{solr}-{run} e.g. d10p81s8-42 (max 11 chars, truncated in create-multidev.sh)
+# Multidev name: {drupal}{php}s{solr}-{run} e.g. 1081s8-2630 (max 11 chars, truncated in create-multidev.sh)
 PHP_SHORT=$(echo "$PHP_VERSION" | tr -d '.')
-echo "MULTIDEV_NAME=d${DRUPAL_VERSION}p${PHP_SHORT}s${SOLR_VERSION}-${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+echo "MULTIDEV_NAME=${DRUPAL_VERSION}${PHP_SHORT}s${SOLR_VERSION}-${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
 
 # Prefix used by cleanup script to find stale multidevs from prior runs
-echo "MULTIDEV_PREFIX=d${DRUPAL_VERSION}p${PHP_SHORT}s${SOLR_VERSION}-" >> "$GITHUB_ENV"
+echo "MULTIDEV_PREFIX=${DRUPAL_VERSION}${PHP_SHORT}s${SOLR_VERSION}-" >> "$GITHUB_ENV"
 
 # Convert git ref to a composer version constraint:
 #   Tags (e.g. 8.5.0-beta1)             -> use as-is: 8.5.0-beta1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
           ssh-private-key: ${{ env.PANTHEON_CI_SSH_KEY }}
 
       - name: Create multidev environment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .github/scripts/create-multidev.sh "$MULTIDEV_NAME" "$TERMINUS_SITE" "$GITHUB_ENV" "$GIT_CONSTRAINT" "$PHP_VERSION"
 
       - name: Show PHP versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,6 @@ jobs:
           ssh-private-key: ${{ env.PANTHEON_CI_SSH_KEY }}
 
       - name: Create multidev environment
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .github/scripts/create-multidev.sh "$MULTIDEV_NAME" "$TERMINUS_SITE" "$GITHUB_ENV" "$GIT_CONSTRAINT" "$PHP_VERSION"
 
       - name: Show PHP versions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ The `.ci/` directory is legacy (old CircleCI-era scripts, not referenced by curr
 
 ### Multidev Naming
 
-Names are truncated to 11 chars (Pantheon limit). Format: `d{drupal}p{php}s{solr}-{run#}` truncated, e.g. `d10p81s8-25`. Parity env replaces last char with `b`, e.g. `d10p81s8-2b`.
+Names are truncated to 11 chars (Pantheon limit). Format: `{drupal}{php}s{solr}-{run#}`, e.g. `1081s8-2630`. Parity env replaces last char with `b`, e.g. `1081s8-263b`. The `d`/`p` letter prefixes were dropped so the 7-char prefix leaves room for the full 4-digit run number (no truncation up to run 9999); the old `d{drupal}p{php}s{solr}-` form truncated the run number away, causing name collisions across concurrent runs.
 
 ### Cleanup Behavior
 


### PR DESCRIPTION
## Summary

Two fixes for the multidev integration tests:

- **Avoid GitHub API 429:** set `no-api: true` on the `search_api_pantheon` VCS repo and clone it over public https, so Composer resolves the branch build via `git` and never calls `api.github.com`.
- **Fix multidev name collision:** drop the `d`/`p` letter prefixes from the multidev name so the run number survives the 11-char truncation.

## Context: GitHub API 429

[SITE-5464](https://getpantheon.atlassian.net/browse/SITE-5464)

Since the #262 CI rework (May 6), `create-multidev.sh` resolves the branch build through a `canonical:false` VCS repo, which makes Composer query `api.github.com/repos/.../commits/<sha>` per commit. Unauthenticated, that uses the anonymous **60/hr per-runner-IP** limit (shared across all GitHub Actions tenants on that IP). The 8-combo D10/D11 x PHP x Solr matrix exhausts it, so **Create multidev environment** fails with:

```
The "https://api.github.com/repos/pantheon-systems/search_api_pantheon/commits/<sha>" file could not be downloaded (HTTP/2 429 ):
Process completed with exit code 100.
```

CI has been red on every branch (including the untouched `8.x` daily cron) since **May 26** — last green run was 2584 on May 25. No commit caused it; the latent unauthenticated-API dependency crossed the rate-limit cliff as anonymous limits tightened and the daily crons run at peak shared-IP usage.

Authenticating the API instead of bypassing it does not solve it: `GITHUB_TOKEN` is capped at **1000/hr per repo** and was not buying the authenticated limit in practice. `no-api` removes the API call entirely, so there is no limit to race. `drupal/devel` comes from packagist (no GitHub API), so no token is needed in this step.

## Context: multidev name collision

Multidev names are truncated to Pantheon's 11-char limit. With the old `d{drupal}p{php}s{solr}-{run}` format the 9-char prefix left only 2 chars for the run number, so truncation kept the leading digits and dropped the varying ones: run 2630 -> `d10p81s8-26`, colliding across runs 2600-2699. Two concurrent runs (different PRs bypass the per-branch concurrency group) produced the same name, and `create-multidev.sh` deletes an existing env before creating, killing the other run mid-test.

Dropping the `d`/`p` letters -> `1081s8-2630`: 7-char prefix, full 4-digit run number fits 11 chars with no truncation up to run 9999.

## Changes

- `.github/scripts/create-multidev.sh` — VCS repo url `git@github.com:` (SSH) → `https://github.com/` + `"no-api": true`.
- `.github/scripts/set-multidev-and-constraint.sh` — multidev name/prefix `d{drupal}p{php}s{solr}-` → `{drupal}{php}s{solr}-`.
- `.github/scripts/cleanup-multidevs.sh` — widen `CI_PATTERN` to match both the new and legacy name forms so old orphans still age-sweep.
- `CLAUDE.md` — update the Multidev Naming doc.

## Test plan

- [ ] CI green across the full matrix: Create-multidev completes with no `api.github.com` request / 429 in the log.
- [ ] Multidev names render as `{drupal}{php}s{solr}-{run}` (e.g. `1081s8-<run>`); concurrent runs no longer collide.


[SITE-5464]: https://getpantheon.atlassian.net/browse/SITE-5464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
