### PR TITLE
Exclude CLAUDE.md from distribution archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 /.gitignore export-ignore
 /codacy.yml export-ignore
 /phpcs.xml export-ignore
+/CLAUDE.md export-ignore


### PR DESCRIPTION
## Summary
- Adds `/CLAUDE.md export-ignore` to `.gitattributes` so the file is excluded from drupal.org distribution tarballs while remaining in the repo for development

## Test plan
- [ ] Verify `.gitattributes` includes the new entry
- [ ] Confirm drupal.org archive builds exclude `CLAUDE.md`