### PR TITLE
Cherry-pick DELENG-435: Add catalog-info.yaml for service catalog onboarding

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -9,4 +9,4 @@ metadata:
 spec:
   type: library
   lifecycle: mature
-  owner: site
+  owner: site-experience


### PR DESCRIPTION
## Summary
- Cherry-picks commit 9b43eae from `8.x` to `8.5.x`
- Adds catalog-info.yaml for service catalog onboarding (originally merged as #256)