### PR TITLE
[SITE-5793] Fix script injection in branch creation workflow

### DIFF
--- a/.github/workflows/create-branch-on-tag.yml
+++ b/.github/workflows/create-branch-on-tag.yml
@@ -37,9 +37,11 @@ jobs:
           echo "MAJOR_BRANCH_NAME=$MAJOR_ONLY" >> $GITHUB_OUTPUT
       - name: Check if branch exists
         id: check_branch
+        env:
+          BRANCH_NAME: ${{ steps.tag_name.outputs.BRANCH_NAME }}
         run: |
           git fetch
-          branch_existence=$(git ls-remote --heads origin ${{ steps.tag_name.outputs.BRANCH_NAME }})
+          branch_existence=$(git ls-remote --heads origin "$BRANCH_NAME")
           if [[ -z ${branch_existence} ]]; then
             echo "Branch for tag does not exist."
             echo "exists=false" >> $GITHUB_OUTPUT
@@ -49,22 +51,30 @@ jobs:
           fi
       - name: Create branch
         if: steps.check_branch.outputs.exists == 'false'
+        env:
+          BRANCH_NAME: ${{ steps.tag_name.outputs.BRANCH_NAME }}
+          MAJOR_BRANCH_NAME: ${{ steps.tag_name.outputs.MAJOR_BRANCH_NAME }}
         run: |
-          git checkout -b ${{ steps.tag_name.outputs.BRANCH_NAME }} origin/${{ steps.tag_name.outputs.MAJOR_BRANCH_NAME }}
-          git push origin ${{ steps.tag_name.outputs.BRANCH_NAME }}
+          git checkout -b "$BRANCH_NAME" "origin/$MAJOR_BRANCH_NAME"
+          git push origin "$BRANCH_NAME"
       - name: Set Git user name and email
         run: |
           git config --global user.name "Pantheon Automation"
           git config --global user.email "bot@getpantheon.com"
       - name: Merge changes from current default branch
         if: steps.check_branch.outputs.exists == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.tag_name.outputs.BRANCH_NAME }}
+          MAJOR_BRANCH_NAME: ${{ steps.tag_name.outputs.MAJOR_BRANCH_NAME }}
         run: |
           git fetch
-          git checkout -b ${{ steps.tag_name.outputs.BRANCH_NAME }} origin/${{ steps.tag_name.outputs.BRANCH_NAME }}
-          git merge origin/${{ steps.tag_name.outputs.MAJOR_BRANCH_NAME }}
-          git push origin HEAD:${{ steps.tag_name.outputs.BRANCH_NAME }}
+          git checkout -b "$BRANCH_NAME" "origin/$BRANCH_NAME"
+          git merge "origin/$MAJOR_BRANCH_NAME"
+          git push origin "HEAD:$BRANCH_NAME"
       - name: Pushes to drupal.org repository
+        env:
+          BRANCH_NAME: ${{ steps.tag_name.outputs.BRANCH_NAME }}
         run: |
           cd $WORKSPACE
           git remote add drupalorg $DRUPAL_ORG_REMOTE
-          git push drupalorg HEAD:${{ steps.tag_name.outputs.BRANCH_NAME }}
+          git push drupalorg "HEAD:$BRANCH_NAME"


### PR DESCRIPTION
## Summary

- Move step outputs (`BRANCH_NAME`, `MAJOR_BRANCH_NAME`) from `run:` blocks to `env:` blocks in create-branch-on-tag.yml (4 steps)

The ci.yml injection findings were resolved by the upstream CI rework (8.5.0 release) and no longer need a separate fix.

## Why

Using `${{ }}` expressions directly inside `run:` blocks is a script injection vulnerability. Step outputs used directly in shell can be exploited if the output value contains shell metacharacters.

The secure pattern is to pass values through `env:` blocks, where they become shell variables instead of being interpolated into the script before shell parsing.

## Test plan

- [ ] Verify create-branch-on-tag workflow still creates branches and pushes to drupal.org on tag push