### PR TITLE
[SITE-5853] Fix CI: allow symfony/runtime Composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "drupal/core-composer-scaffold": true
+            "drupal/core-composer-scaffold": true,
+            "symfony/runtime": true
         }
     },
     "extra": {


### PR DESCRIPTION
## Summary
- Add `symfony/runtime` to `allow-plugins` in `composer.json`
- Drupal core 11.4.4 pulls in `symfony/runtime` as a transitive dependency, which Composer blocks if not explicitly allowed — breaking the linting job

## Test plan
- [ ] CI linting job passes on this branch

SITE-5853