### PR TITLE
Add pull_request trigger to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ concurrency:
 
 on:
   push:
+  pull_request:
   repository_dispatch:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ concurrency:
 
 on:
   push:
+    branches:
+      - 8.x
   pull_request:
   repository_dispatch:
   schedule:


### PR DESCRIPTION
## Summary

- ci.yml triggered on `push` (all branches), `schedule`, and `workflow_dispatch` but not `pull_request`, meaning CI ran after merge and on nightly but not on PRs
- Narrowed `push` to `8.x` (default branch) only, added `pull_request` trigger so tests run before merge
- `push` is restricted to `8.x` to avoid duplicate CI runs: without this, pushing to a PR branch fires both `push` and `pull_request` events simultaneously, running the same tests twice

## Why

Ensure tests run on PRs so failures are caught before merge. This also mitigates the GitHub 60-day inactivity issue: if nightly CI gets silently disabled on a quiet repo, PR-triggered tests still catch problems before they land on main.

Part of [SITE-6011](https://getpantheon.atlassian.net/browse/SITE-6011).

[SITE-6011]: https://getpantheon.atlassian.net/browse/SITE-6011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ