### PR TITLE
fix: [SITE-6063] Surface gateway error response body in schema post errors

### DIFF
--- a/src/Services/SchemaPoster.php
+++ b/src/Services/SchemaPoster.php
@@ -176,7 +176,7 @@ class SchemaPoster implements LoggerAwareInterface {
           $message .= "\n" . $this->t('Gateway response: @body', ['@body' => $body]);
         }
         else {
-          $message .= "\n" . $this->t('The server encountered an internal error. Check the search gateway logs for details.');
+          $message .= "\n" . $this->t('The server encountered an internal error. Please contact Pantheon support for assistance.');
         }
       }
     }

--- a/src/Services/SchemaPoster.php
+++ b/src/Services/SchemaPoster.php
@@ -162,11 +162,25 @@ class SchemaPoster implements LoggerAwareInterface {
    */
   public function processResponse(Response $response): array {
     $logMethod = PantheonSolrConnector::getLogMethod($response);
+    $status_code = $response->getStatusCode();
     $message = vsprintf($this->t('Result: %s Status code: %d - %s'), [
       $logMethod == 'error' ? 'NOT UPLOADED' : 'UPLOADED',
-      $response->getStatusCode(),
+      $status_code,
       $response->getStatusMessage(),
     ]);
+
+    if ($logMethod === 'error') {
+      $body = $response->getBody();
+      if (!empty($body)) {
+        if ($status_code >= 400 && $status_code < 500) {
+          $message .= "\n" . $this->t('Gateway response: @body', ['@body' => $body]);
+        }
+        else {
+          $message .= "\n" . $this->t('The server encountered an internal error. Check the search gateway logs for details.');
+        }
+      }
+    }
+
     return [$logMethod, $message];
   }
 


### PR DESCRIPTION
## Summary

- Surface the gateway response body in `SchemaPoster::processResponse()` when schema upload fails
- 4xx errors show the parsed response body so users can see the actual rejection reason
